### PR TITLE
Update .clang-format formatting of function declaration parameters

### DIFF
--- a/cpp/formatting/.clang-format
+++ b/cpp/formatting/.clang-format
@@ -6,7 +6,7 @@ AlignConsecutiveDeclarations: false
 AlignEscapedNewlinesLeft: true
 AlignOperands: true
 AlignTrailingComments: true
-AllowAllParametersOfDeclarationOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
@@ -16,7 +16,7 @@ AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: true
 BasedOnStyle: WebKit
 BinPackArguments: true
-BinPackParameters: true
+BinPackParameters: false
 BraceWrapping:
   AfterClass: false
   AfterControlStatement: false

--- a/cpp/formatting/README.md
+++ b/cpp/formatting/README.md
@@ -30,8 +30,13 @@ A C++ snippet has the following structure:
 
 // optional *markown* description
 // Multiline description is supported
+// clang-format: KEY: VALUE
+// clang-format: KEY: VALUE
+
 
 template <typename T>
 your cpp(code);
 ```
-If a C++ snippet highlights a particular clang-format configuration key, then it should be named after it.
+
+If a C++ snippet highlights a particular clang-format configuration key, then it should be named after it. Additional Clang-Format key/value
+can be referenced in the C++ snippet directly.

--- a/cpp/formatting/formatting.md.jinja
+++ b/cpp/formatting/formatting.md.jinja
@@ -3,22 +3,26 @@
 This document provides a set of examples to highlight C++
 code formatting conventions adopted by BlueBrain HPC team.
 
-## Similar work
+# Similar work
 
 * NSE Team also provides [such document](https://bbpteam.epfl.ch/project/spaces/pages/viewpage.action?spaceKey=BBPNSE&title=Code+style)
 
-## Conventions
+# Conventions
 
 {% for conv in conventions %}
-### {{ conv.title}}
+## {{ conv.title}}
 {%- if conv.description %}
 {{ conv.description }}
 {%- endif %}
 
+### Example
 ```cpp
 {{ conv.snippet }}
 ```
-{%- if conv.clang_format_key %}
-clang-format: `{{ conv.clang_format_key }}: {{ conv.clang_format_value }}`
+{%- if conv.clang_format %}
+### Clang-Format configuration
 {%- endif %}
+{%- for key, value in conv.clang_format.items() %}
+* `{{ key }}: {{ value }}`
+{%- endfor %}
 {% endfor %}

--- a/cpp/formatting/snippets/AlignAfterOpenBracket.cpp
+++ b/cpp/formatting/snippets/AlignAfterOpenBracket.cpp
@@ -1,4 +1,7 @@
 // Horizontally aligns arguments after an open bracket
 
-thisIsAVeryLongMethodName(thisIsTheFirstArgument, andHereIsTheSecondArgument, theThirdArgument,
-                          theFourthArgument, theFifthArgument);
+thisIsAVeryLongMethodName(thisIsTheFirstArgument,
+                          andHereIsTheSecondArgument,
+                          theThirdArgument,
+                          theFourthArgument,
+                          theFifthArgument);

--- a/cpp/formatting/snippets/AlignOperands.cpp
+++ b/cpp/formatting/snippets/AlignOperands.cpp
@@ -1,4 +1,5 @@
 // Horizontally align operands of binary and ternary expressions.
+//
 
 // clang-format off
 int aaa = bbbbbbbbbbbbbbb +

--- a/cpp/formatting/snippets/AllowAllParametersOfDeclarationOnNextLine.cpp.skip
+++ b/cpp/formatting/snippets/AllowAllParametersOfDeclarationOnNextLine.cpp.skip
@@ -1,7 +1,0 @@
-// Put parameters on next line if it does not fit
-
-// current .clang-format does not format like what is described in clang-format
-// documentation. So exclude this snippet for now from documentation
-
-thisIsALongType andAVeryLongFunctionName(the_long_parameter1, the_long_parameter2,
-                                         the_long_parameter3, the_long_parameter4)

--- a/cpp/formatting/snippets/one-parameter-per-line-if-they-do-no-fit.cpp
+++ b/cpp/formatting/snippets/one-parameter-per-line-if-they-do-no-fit.cpp
@@ -1,0 +1,10 @@
+// One parameter per line if they don't all fit
+// clang-format: AllowAllParametersOfDeclarationOnNextLine: false
+// clang-format: BinPackParameters: False
+
+HighFive::DataSet dump(HighFive::File& file,
+                       const std::string& path,
+                       const std::vector<T>& data,
+                       HighFive::Mode mode = HighFive::Mode::Create);
+
+void andALongFunctionName(the_long_parameter1, the_long_parameter2);


### PR DESCRIPTION
@pramodk @ferdonline and I agree that function declaration should be specified in one line if declaration fits. Otherwise, there should have one parameter per line.