### PR TITLE
Change clang-format to only put empty functions onto single lines

### DIFF
--- a/cpp/.clang-format
+++ b/cpp/.clang-format
@@ -9,7 +9,7 @@ AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: true

--- a/cpp/formatting/README.md
+++ b/cpp/formatting/README.md
@@ -128,14 +128,10 @@ case 3: return;  // NOT THIS
 ### Clang-Format configuration
 * `AllowShortCaseLabelsOnASingleLine: False`
 
-## Only short methods inside a struct or class can be put in a single line
+## Only empty methods can be put in a single line
 
 ### Example
 ```cpp
-class Foo {
-    void f() { foo(); }
-};
-
 void f() {
     foo();
 }
@@ -144,7 +140,7 @@ void f() {}
 
 ```
 ### Clang-Format configuration
-* `AllowShortFunctionsOnASingleLine: Inline`
+* `AllowShortFunctionsOnASingleLine: Empty`
 
 ## Conditions
 Break even for simple `if` statement and always put body inside braces.

--- a/cpp/formatting/README.md
+++ b/cpp/formatting/README.md
@@ -132,11 +132,13 @@ case 3: return;  // NOT THIS
 
 ### Example
 ```cpp
-void f() {
-    foo();
-}
+class Foo {
+  void f() {
+      foo();
+  }
 
-void f() {}
+  void f() {}
+};
 
 ```
 ### Clang-Format configuration

--- a/cpp/formatting/snippets/AllowShortFunctionsOnASingleLine.cpp
+++ b/cpp/formatting/snippets/AllowShortFunctionsOnASingleLine.cpp
@@ -1,8 +1,4 @@
-// Only short methods inside a struct or class can be put in a single line
-
-class Foo {
-    void f() { foo(); }
-};
+// Only empty methods can be put in a single line
 
 void f() {
     foo();

--- a/cpp/formatting/snippets/AllowShortFunctionsOnASingleLine.cpp
+++ b/cpp/formatting/snippets/AllowShortFunctionsOnASingleLine.cpp
@@ -1,7 +1,9 @@
 // Only empty methods can be put in a single line
 
-void f() {
-    foo();
-}
+class Foo {
+  void f() {
+      foo();
+  }
 
-void f() {}
+  void f() {}
+};


### PR DESCRIPTION
Just a small change updating the clang-format file according to HPC team discussion.