### PR TITLE
bump cmake version number

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.12)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)


### PR DESCRIPTION
This line
`find_package(Python COMPONENTS Interpreter REQUIRED)`
requires cmake >= 3.12

Alternatively could replace it with 
`find_package(PythonInterp REQUIRED)`