### PR TITLE
Update sphinx dependency version

### DIFF
--- a/cpp/Documentation.md
+++ b/cpp/Documentation.md
@@ -401,7 +401,7 @@ doc_requirements = [
     "exhale",
     "m2r",
     "sphinx-rtd-theme",
-    "sphinx<2"
+    "sphinx>=2"
 ]
 setup(
     # [...]


### PR DESCRIPTION
Updated `setup.py` example to reflect breathe version dependency change to sphinx:

c.f. https://github.com/michaeljones/breathe/releases/tag/v4.13.0.post0