### PR TITLE
Less hooks

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,6 +9,7 @@ function(bbp_enable_precommit)
   execute_process(COMMAND ${PreCommit_EXECUTABLE} install)
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
+            --regenerate-hooks ${PROJECT_NAME}_PRECOMMIT_REGEN
             --clang-format ${${PROJECT_NAME}_FORMATTING} --cmake-format
             ${${PROJECT_NAME}_FORMATTING} --clang-tidy ${${PROJECT_NAME}_STATIC_ANALYSIS}
             ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
@@ -83,7 +84,7 @@ function(bbp_enable_formatting)
   set(${PROJECT_NAME}_CMakeFormat_OPTIONS "" CACHE STRING "cmake-format options")
   set(${PROJECT_NAME}_CMakeFormat_FILES_RE "^.*\\\\.cmake$$" "^.*CMakeLists.txt$$"
       CACHE STRING "List of regular expressions matching CMake files")
-  set(${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
+  set(${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$" ".*/.*build.*/.*$$" ".*/ext.*/.*$$"
       CACHE STRING "list of regular expressions to exclude CMake files from formatting")
   mark_as_advanced(${PROJECT_NAME}_CMakeFormat_OPTIONS ${PROJECT_NAME}_CMakeFormat_FILES_RE
                    ${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE)
@@ -164,6 +165,7 @@ endfunction(bbp_enable_static_analysis)
 bob_option(${PROJECT_NAME}_FORMATTING "Enable helpers to keep CMake and C++ code properly formatted"
            OFF)
 bob_option(${PROJECT_NAME}_PRECOMMIT "Enable automatic checks before git commits" OFF)
+bob_option(${PROJECT_NAME}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
 bob_option(${PROJECT_NAME}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
 
 if(${PROJECT_NAME}_FORMATTING)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ function(bbp_enable_precommit)
   execute_process(COMMAND ${PreCommit_EXECUTABLE} install)
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
-            --regenerate-hooks ${${PROJECT_NAME}_PRECOMMIT_REGEN}
+            --force ${${PROJECT_NAME}_PRECOMMIT_REGEN}
             --clang-format ${${PROJECT_NAME}_FORMATTING} --cmake-format
             ${${PROJECT_NAME}_FORMATTING} --clang-tidy ${${PROJECT_NAME}_STATIC_ANALYSIS}
             ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -26,8 +26,8 @@ function(bbp_disable_precommit)
   endif()
 endfunction(bbp_disable_precommit)
 
-function(bbp_enable_formatting)
-  find_package(PythonInterp 3.5 REQUIRED)
+function(bbp_enable_clang_formatting)
+  find_package(Python COMPONENTS Interpreter REQUIRED)
   find_package(ClangFormat 7 EXACT REQUIRED)
   set(${PROJECT_NAME}_ClangFormat_OPTIONS "" CACHE STRING "clang-format command options")
   set(${PROJECT_NAME}_ClangFormat_FILES_RE "^.*\\\\.[ch]$$" "^.*\\\\.[chi]pp$$"
@@ -79,10 +79,15 @@ function(bbp_enable_formatting)
     add_dependencies(clang-format ${${PROJECT_NAME}_ClangFormat_DEPENDENCIES})
     add_dependencies(check-clang-format ${${PROJECT_NAME}_ClangFormat_DEPENDENCIES})
   endif()
+endfunction(bbp_enable_clang_formatting)
 
-  find_package(CMakeFormat REQUIRED)
-  set(${PROJECT_NAME}_CMakeFormat_OPTIONS "" CACHE STRING "cmake-format options")
-  set(${PROJECT_NAME}_CMakeFormat_FILES_RE "^.*\\\\.cmake$$" "^.*CMakeLists.txt$$"
+function(bbp_enable_cmake_formatting)
+  find_package(PythonInterp 3.5 REQUIRED)
+  find_package(CMakeFormat 0.4.5 EXACT REQUIRED)
+  set(${PROJECT_NAME}_CMakeFormat_OPTIONS ""
+      CACHE STRING "cmake-format options")
+  set(${PROJECT_NAME}_CMakeFormat_FILES_RE "^.*\\\\.cmake$$"
+      "^.*CMakeLists.txt$$"
       CACHE STRING "List of regular expressions matching CMake files")
   set(${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE
       ".*/third[-_]parties/.*$$"
@@ -123,7 +128,7 @@ function(bbp_enable_formatting)
                     check
                     --
                     ${${PROJECT_NAME}_CMakeFormat_OPTIONS})
-endfunction(bbp_enable_formatting)
+endfunction(bbp_enable_cmake_formatting)
 
 function(bbp_enable_static_analysis)
   find_package(PythonInterp 3.5 REQUIRED)
@@ -166,12 +171,26 @@ endfunction(bbp_enable_static_analysis)
 
 bob_option(${PROJECT_NAME}_FORMATTING "Enable helpers to keep CMake and C++ code properly formatted"
            OFF)
+bob_option(${PROJECT_NAME}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted"
+           OFF)
+bob_option(${PROJECT_NAME}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted"
+           OFF)
+
 bob_option(${PROJECT_NAME}_PRECOMMIT "Enable automatic checks before git commits" OFF)
 bob_option(${PROJECT_NAME}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
 bob_option(${PROJECT_NAME}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
 
+if(${PROJECT_NAME}_CLANG_FORMAT)
+  bbp_enable_clang_formatting()
+endif(${PROJECT_NAME}_CLANG_FORMAT)
+
+if(${PROJECT_NAME}_CMAKE_FORMAT)
+  bbp_enable_cmake_formatting()
+endif(${PROJECT_NAME}_CMAKE_FORMAT)
+
 if(${PROJECT_NAME}_FORMATTING)
-  bbp_enable_formatting()
+  bbp_enable_clang_formatting()
+  bbp_enable_cmake_formatting()
 endif(${PROJECT_NAME}_FORMATTING)
 
 if(${PROJECT_NAME}_PRECOMMIT)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -49,6 +49,7 @@ function(bbp_enable_clang_formatting)
                     --executable="${ClangFormat_EXECUTABLE}"
                     --files-re
                     ${${PROJECT_NAME}_ClangFormat_FILES_RE}
+                    $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
                     --excludes-re
                     ${${PROJECT_NAME}_ClangFormat_EXCLUDES_RE}
                     -p
@@ -67,6 +68,7 @@ function(bbp_enable_clang_formatting)
                     --executable="${ClangFormat_EXECUTABLE}"
                     --files-re
                     ${${PROJECT_NAME}_ClangFormat_FILES_RE}
+                    $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
                     --excludes-re
                     ${${PROJECT_NAME}_ClangFormat_EXCLUDES_RE}
                     -p
@@ -106,6 +108,7 @@ function(bbp_enable_cmake_formatting)
                     --executable="${CMakeFormat_EXECUTABLE}"
                     --files-re
                     ${${PROJECT_NAME}_CMakeFormat_FILES_RE}
+                    $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
                     --excludes-re
                     ${${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE}
                     --action
@@ -122,6 +125,7 @@ function(bbp_enable_cmake_formatting)
                     --executable="${CMakeFormat_EXECUTABLE}"
                     --files-re
                     ${${PROJECT_NAME}_CMakeFormat_FILES_RE}
+                    $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
                     --excludes-re
                     ${${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE}
                     --action
@@ -155,6 +159,7 @@ function(bbp_enable_static_analysis)
                     --executable="${ClangTidy_EXECUTABLE}"
                     --files-re
                     ${${PROJECT_NAME}_ClangTidy_FILES_RE}
+                    $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
                     --excludes-re
                     ${${PROJECT_NAME}_ClangTidy_EXCLUDES_RE}
                     -p
@@ -171,6 +176,8 @@ endfunction(bbp_enable_static_analysis)
 
 bob_option(${PROJECT_NAME}_FORMATTING "Enable helpers to keep CMake and C++ code properly formatted"
            OFF)
+bob_option(${PROJECT_NAME}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting"
+           ON)
 bob_option(${PROJECT_NAME}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted"
            OFF)
 bob_option(${PROJECT_NAME}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted"

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,7 +9,7 @@ function(bbp_enable_precommit)
   execute_process(COMMAND ${PreCommit_EXECUTABLE} install)
   execute_process(
     COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
-            --regenerate-hooks ${PROJECT_NAME}_PRECOMMIT_REGEN
+            --regenerate-hooks ${${PROJECT_NAME}_PRECOMMIT_REGEN}
             --clang-format ${${PROJECT_NAME}_FORMATTING} --cmake-format
             ${${PROJECT_NAME}_FORMATTING} --clang-tidy ${${PROJECT_NAME}_STATIC_ANALYSIS}
             ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
@@ -84,7 +84,9 @@ function(bbp_enable_formatting)
   set(${PROJECT_NAME}_CMakeFormat_OPTIONS "" CACHE STRING "cmake-format options")
   set(${PROJECT_NAME}_CMakeFormat_FILES_RE "^.*\\\\.cmake$$" "^.*CMakeLists.txt$$"
       CACHE STRING "List of regular expressions matching CMake files")
-  set(${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$" ".*/.*build.*/.*$$" ".*/ext.*/.*$$"
+  set(${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE
+      ".*/third[-_]parties/.*$$"
+      ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude CMake files from formatting")
   mark_as_advanced(${PROJECT_NAME}_CMakeFormat_OPTIONS ${PROJECT_NAME}_CMakeFormat_FILES_RE
                    ${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE)

--- a/cpp/cmake/bbp-cmake-format.py
+++ b/cpp/cmake/bbp-cmake-format.py
@@ -56,6 +56,8 @@ def collect_files(cmake_source_dir, cmake_binary_dir, excludes_re, cmake_files_r
             if osp.isdir(p):
                 if f in EXCLUDED_DIRS:
                     continue
+                elif osp.isfile(osp.join(p, "CMakeCache.txt")):
+                    continue
                 queue.append(p)
             else:
                 if f in EXCLUDED_FILES:

--- a/cpp/cmake/bbp-setup-pre-commit-config.py
+++ b/cpp/cmake/bbp-setup-pre-commit-config.py
@@ -37,6 +37,12 @@ def _parse_cli(args=None):
         nargs="?",
     )
     parser.add_argument(
+        "--regenerate-hooks",
+        type=str2bool,
+        help="Regenerate pre-commit hooks",
+        default=False,
+    )
+    parser.add_argument(
         "--cmake-format", type=str2bool, help="Enable CMake files code formatting check"
     )
     parser.add_argument(
@@ -91,11 +97,14 @@ def disable_cmake_hook(repo, hook_id):
 def main(**kwargs):
     args = _parse_cli(**kwargs)
     PRE_COMMIT_CONFIG = osp.join(args.source_dir, ".pre-commit-config.yaml")
-    if not osp.exists(PRE_COMMIT_CONFIG):
-        config = {}
+    if osp.exists(PRE_COMMIT_CONFIG):
+        if not args.regenerate_hooks:
+            return
+        else:
+            with open(PRE_COMMIT_CONFIG) as istr:
+                config = yaml.load(istr, Loader=Loader) or {}
     else:
-        with open(PRE_COMMIT_CONFIG) as istr:
-            config = yaml.load(istr, Loader=Loader) or {}
+        config = {}
 
     repo = get_or_set_bbp_pre_commit_repo(config)
     if args.clang_format:

--- a/cpp/cmake/bbp-setup-pre-commit-config.py
+++ b/cpp/cmake/bbp-setup-pre-commit-config.py
@@ -37,9 +37,9 @@ def _parse_cli(args=None):
         nargs="?",
     )
     parser.add_argument(
-        "--regenerate-hooks",
+        "-f", "--force",
         type=str2bool,
-        help="Regenerate pre-commit hooks",
+        help="Force regenerating pre-commit hooks",
         default=False,
     )
     parser.add_argument(


### PR DESCRIPTION
@matz-e and I thought to improve the cmake format pre-commits

- freeze the versions used (as in the case of cmake-format, 0.5.0 was buggy, followed by 0.5.1, which produced significatnly different output in the CMakeLists.txt files). A change in cmake-format (and clang-format) shoudl be a conscious decision in the hpc-coding-conventions repo and not done transparently.
- include less files to format, ideally we should only format files in the change list, but this would require more work later
- ignore git submodules and CMakeCache.txt files.