### PR TITLE
bugfix: reject absolute paths for both C++ and CMake

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -111,6 +111,8 @@ A list of CMake cache variables can be used to customize the code formatting:
 * `${PROJECT}_ClangFormat_EXCLUDES_RE`: list of regular expressions to exclude C/C++ files
   from formatting. Default value is:<br/>
   `".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"`
+
+  Regular expressions are tested against the **full file path**.
 * `${PROJECT}_ClangFormat_DEPENDENCIES`: list of CMake targets to build before
   formatting C/C++ code. Default value is `""`
 

--- a/cpp/cmake/bbp-cmake-format.py
+++ b/cpp/cmake/bbp-cmake-format.py
@@ -53,31 +53,31 @@ def collect_files(cmake_source_dir, cmake_binary_dir, excludes_re, cmake_files_r
             rp = p[len(cmake_source_dir):]
             if p == cmake_binary_dir:
                 continue
-            if osp.isdir(p):
-                if f in EXCLUDED_DIRS:
-                    continue
-                elif osp.isfile(osp.join(p, "CMakeCache.txt")):
-                    continue
-                queue.append(p)
+            for regex in excludes_re:
+                if regex.match(p):
+                    break
             else:
-                if f in EXCLUDED_FILES:
-                    continue
-                coupled_suffixes = ["Config.cmake", "ConfigVersion.cmake"]
-                for i in range(len(coupled_suffixes)):
-                    if f.endswith(coupled_suffixes[i]):
-                        base = f[: -len(coupled_suffixes[i])]
-                        if osp.isfile(
-                            osp.join(
-                                d,
-                                base
-                                + coupled_suffixes[(i + 1) % len(coupled_suffixes)],
-                            )
-                        ):
-                            break
+                if osp.isdir(p):
+                    if f in EXCLUDED_DIRS:
+                        continue
+                    elif osp.isfile(osp.join(p, "CMakeCache.txt")):
+                        continue
+                    queue.append(p)
                 else:
-                    for regex in excludes_re:
-                        if regex.match(rp):
-                            break
+                    if f in EXCLUDED_FILES:
+                        continue
+                    coupled_suffixes = ["Config.cmake", "ConfigVersion.cmake"]
+                    for i in range(len(coupled_suffixes)):
+                        if f.endswith(coupled_suffixes[i]):
+                            base = f[: -len(coupled_suffixes[i])]
+                            if osp.isfile(
+                                osp.join(
+                                    d,
+                                    base
+                                    + coupled_suffixes[(i + 1) % len(coupled_suffixes)],
+                                )
+                            ):
+                                break
                     else:
                         for regexp in cmake_files_re:
                             if regexp.match(rp):


### PR DESCRIPTION
Adjust the CMake formatting behavior to match full paths rather than
relative ones, as both the documented defaults match full paths, and
`clang-format` does, too.

Also filter more aggressively. Once we encounter an excluded directory,
there is no need to descend into it.