### PR TITLE
New `${PROJECT_NAME}_FORMATTING_APPLIES_ON:STRING` CMake variable

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -53,10 +53,8 @@ function(bbp_enable_clang_formatting)
       --excludes-re
       ${${PROJECT_NAME}_ClangFormat_EXCLUDES_RE}
       -p
-      ${CMAKE_BINARY_DIR}/compile_commands.json)
-  if(${PROJECT_NAME}_FORMATTING_STAGED_ONLY)
-    set(clang_format_command_prefix ${clang_format_command_prefix} --staged-only)
-  endif()
+      ${CMAKE_BINARY_DIR}/compile_commands.json
+      --applies-on=${${PROJECT_NAME}_FORMATTING_ON})
   add_custom_target(clang-format
                     ${clang_format_command_prefix}
                     --action
@@ -105,10 +103,8 @@ function(bbp_enable_cmake_formatting)
       ${${PROJECT_NAME}_CMakeFormat_FILES_RE}
       $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE})
-  if(${PROJECT_NAME}_FORMATTING_STAGED)
-    set(cmake_format_command_prefix ${cmake_format_command_prefix} --staged)
-  endif()
+      ${${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE}
+      --applies-on=${${PROJECT_NAME}_FORMATTING_ON})
   add_custom_target(cmake-format
                     ${cmake_format_command_prefix}
                     --action
@@ -178,8 +174,9 @@ endfunction(bbp_enable_static_analysis)
 
 bob_option(${PROJECT_NAME}_FORMATTING "Enable helpers to keep CMake and C++ code properly formatted"
            OFF)
-bob_option(${PROJECT_NAME}_FORMATTING_STAGED
-           "Perform formatting checks only on files in the git staging area" OFF)
+bob_option(${PROJECT_NAME}_FORMATTING_ON
+           "Specify changeset where formatting applies (see documentation for detailed information)"
+           all)
 bob_option(${PROJECT_NAME}_TEST_FORMATTING "Add CTest formatting test" OFF)
 bob_option(${PROJECT_NAME}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
 bob_option(${PROJECT_NAME}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -54,6 +54,9 @@ function(bbp_enable_clang_formatting)
       ${${PROJECT_NAME}_ClangFormat_EXCLUDES_RE}
       -p
       ${CMAKE_BINARY_DIR}/compile_commands.json)
+  if(${PROJECT_NAME}_FORMATTING_STAGED_ONLY)
+    set(clang_format_command_prefix ${clang_format_command_prefix} --staged-only)
+  endif()
   add_custom_target(clang-format
                     ${clang_format_command_prefix}
                     --action
@@ -103,6 +106,9 @@ function(bbp_enable_cmake_formatting)
       $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
       ${${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE})
+  if(${PROJECT_NAME}_FORMATTING_STAGED)
+    set(cmake_format_command_prefix ${cmake_format_command_prefix} --staged)
+  endif()
   add_custom_target(cmake-format
                     ${cmake_format_command_prefix}
                     --action
@@ -131,7 +137,7 @@ function(bbp_enable_static_analysis)
   set(${PROJECT_NAME}_ClangTidy_OPTIONS -extra-arg=-Wno-unknown-warning-option
       CACHE STRING "clang-tidy command options")
   mark_as_advanced(${PROJECT_NAME}_ClangTidy_OPTIONS)
-  set(${PROJECT_NAME}_ClangTidy_FILES_RE "^.*\\\\.c$$"  "^.*\\\\.cpp$$"
+  set(${PROJECT_NAME}_ClangTidy_FILES_RE "^.*\\\\.c$$" "^.*\\\\.cpp$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
   set(${PROJECT_NAME}_ClangTidy_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")
@@ -141,26 +147,28 @@ function(bbp_enable_static_analysis)
                    ${PROJECT_NAME}_ClangTidy_EXCLUDES_RE)
   configure_file(.clang-tidy ${PROJECT_SOURCE_DIR})
   set(clang_tidy_command_prefix
-          ${PYTHON_EXECUTABLE}
-          "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-clang-tidy.py"
-          -S
-          "${CMAKE_SOURCE_DIR}"
-          -B
-          "${CMAKE_BINARY_DIR}"
-          "--executable=${ClangTidy_EXECUTABLE}"
-          --files-re
-          "${${PROJECT_NAME}_ClangTidy_FILES_RE}"
-          $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
-          --excludes-re
-          ${${PROJECT_NAME}_ClangTidy_EXCLUDES_RE}
-          -p
-          ${CMAKE_BINARY_DIR}/compile_commands.json
-          --action
-          check
-          )
+      ${PYTHON_EXECUTABLE}
+      "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-clang-tidy.py"
+      -S
+      "${CMAKE_SOURCE_DIR}"
+      -B
+      "${CMAKE_BINARY_DIR}"
+      "--executable=${ClangTidy_EXECUTABLE}"
+      --files-re
+      "${${PROJECT_NAME}_ClangTidy_FILES_RE}"
+      $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      --excludes-re
+      ${${PROJECT_NAME}_ClangTidy_EXCLUDES_RE}
+      -p
+      ${CMAKE_BINARY_DIR}/compile_commands.json
+      --action
+      check)
   add_custom_target(clang-tidy ${clang_tidy_command_prefix} -- ${${PROJECT_NAME}_ClangTidy_OPTIONS})
   if(${PROJECT_NAME}_TEST_STATIC_ANALYSIS)
-    add_test(NAME ClangTidy COMMAND ${clang_tidy_command_prefix} --make-unescape-re -- ${${PROJECT_NAME}_ClangTidy_OPTIONS})
+    add_test(NAME ClangTidy
+             COMMAND ${clang_tidy_command_prefix}
+                     --make-unescape-re
+                     -- ${${PROJECT_NAME}_ClangTidy_OPTIONS})
   endif()
   if(${PROJECT_NAME}_ClangTidy_DEPENDENCIES)
     add_dependencies(clang-tidy ${${PROJECT_NAME}_ClangTidy_DEPENDENCIES})
@@ -170,6 +178,8 @@ endfunction(bbp_enable_static_analysis)
 
 bob_option(${PROJECT_NAME}_FORMATTING "Enable helpers to keep CMake and C++ code properly formatted"
            OFF)
+bob_option(${PROJECT_NAME}_FORMATTING_STAGED
+           "Perform formatting checks only on files in the git staging area" OFF)
 bob_option(${PROJECT_NAME}_TEST_FORMATTING "Add CTest formatting test" OFF)
 bob_option(${PROJECT_NAME}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
 bob_option(${PROJECT_NAME}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -97,9 +97,22 @@ CMake variables:
 * `${PROJECT}_CMAKE_FORMAT:BOOL`
 
 Although it is possible to overwrite the default settings to restrict the scanned
-directories, the formatting applies to the entire repository.
-To perform the formatting only on files in the git staging area,
-enable the `${PROJECT}_FORMATTING_STAGED_ONLY:BOOL` CMake variable.
+directories, the formatting applies to the entire repository by default.
+
+Use `${PROJECT}_FORMATTING_ON:STRING` CMake variable to apply formatting on a subset.
+Possible values are:
+* `all`: apply formatting on the entire repository (the default).
+* `staged`: apply formatting only on added and modified files in the git staging area.
+* `since-ref:GIT_REF`: apply formatting only on added and modified files in the commits
+since the given ref. For instance `since-ref:origin/master` is equivalent to:
+   ```
+   fork_point=`git merge-base --fork-point origin/master HEAD`
+   git diff --name-status $fork_point | grep '^[AM]'
+   ```
+* `base-branch`: an alias for `since-ref:$CHANGE_TARGET`. CHANGE_TARGET is a Jenkins
+environment variable that contains the target or base branch to which the change
+could be merged.
+* `since-rev:GIT_REV`. For instance `since-ref:fcfc8b6a`
 
 ##### Usage
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -97,7 +97,11 @@ CMake variables:
 * `${PROJECT}_CMAKE_FORMAT:BOOL`
 
 Although it is possible to overwrite the default settings to restrict the scanned
-directories, the formatting applies to the entire repository by default.
+directories, the formatting applies to the entire repository except git submodules
+by default.
+
+To enable the formatting of CMake and C++ code inside git submodules, enable the
+`${PROJECT_NAME}_FORMATTING_NO_SUBMODULES:BOOL` CMake variable.
 
 Use `${PROJECT}_FORMATTING_ON:STRING` CMake variable to apply formatting on a subset.
 Possible values are:

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -96,6 +96,11 @@ CMake variables:
 * `${PROJECT}_CLANG_FORMAT:BOOL`
 * `${PROJECT}_CMAKE_FORMAT:BOOL`
 
+Although it is possible to overwrite the default settings to restrict the scanned
+directories, the formatting applies to the entire repository.
+To perform the formatting only on files in the git staging area,
+enable the `${PROJECT}_FORMATTING_STAGED_ONLY:BOOL` CMake variable.
+
 ##### Usage
 
 This will add the following *make* targets:

--- a/cpp/cmake/bbp-clang-format.py
+++ b/cpp/cmake/bbp-clang-format.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import tempfile
 
-from cpplib import collect_files, log_command, make_cpp_file_filter, parse_cli
+from cpplib import collect_files, filter_git_modified, log_command, make_cpp_file_filter, parse_cli
 
 
 def do_format(cpp_file, clang_format, options):
@@ -62,7 +62,7 @@ def main(**kwargs):
     )
     with build_action_func(args) as action:
         succeeded = True
-        for cpp_file in collect_files(args.compile_commands_file, filter_cpp_file):
+        for cpp_file in filter_git_modified(args, collect_files(args.compile_commands_file, filter_cpp_file)):
             succeeded &= action(cpp_file, args.executable, args.options)
     return succeeded
 

--- a/cpp/cmake/bbp-cmake-format.py
+++ b/cpp/cmake/bbp-cmake-format.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 
-from cpplib import log_command, parse_cli
+from cpplib import filter_git_modified, log_command, parse_cli
 
 
 def _build_excluded_dirs():
@@ -90,7 +90,6 @@ def do_format(cmake_file, cmake_format, options):
         cmd.append("-i")
     cmd.append(cmake_file)
     log_command(cmd)
-    LOGGER.info(" ".join(cmd))
     return subprocess.call(cmd) == 0
 
 
@@ -132,9 +131,9 @@ def main(**kwargs):
     files_re = [re.compile(r) for r in args.files_re]
     with build_action_func(args) as action:
         succeeded = True
-        for cmake_file in collect_files(
+        for cmake_file in filter_git_modified(args, collect_files(
             args.source_dir, args.binary_dir, excludes_re, files_re
-        ):
+        )):
             succeeded &= action(cmake_file, args.executable, args.options)
     return succeeded
 


### PR DESCRIPTION
This new boolean CMake variable allows one to only perform formatting checks on the files in the git staged area.

Fixes #36