### PR TITLE
Update file extensions for formatting / name of C++ headers

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -30,7 +30,12 @@ function(bbp_enable_clang_formatting)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(ClangFormat 7 EXACT REQUIRED)
   set(${PROJECT_NAME}_ClangFormat_OPTIONS "" CACHE STRING "clang-format command options")
-  set(${PROJECT_NAME}_ClangFormat_FILES_RE "^.*\\\\.[ch]$$" "^.*\\\\.[chi]pp$$"
+  set(${PROJECT_NAME}_ClangFormat_FILES_RE
+      "^.*\\\\.cc?$$"
+      "^.*\\\\.hh?$$"
+      "^.*\\\\.[it]cc$$"
+      "^.*\\\\.[chit]pp$$"
+      "^.*\\\\.[chit]xx$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
   set(${PROJECT_NAME}_ClangFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")
@@ -133,7 +138,10 @@ function(bbp_enable_static_analysis)
   set(${PROJECT_NAME}_ClangTidy_OPTIONS -extra-arg=-Wno-unknown-warning-option
       CACHE STRING "clang-tidy command options")
   mark_as_advanced(${PROJECT_NAME}_ClangTidy_OPTIONS)
-  set(${PROJECT_NAME}_ClangTidy_FILES_RE "^.*\\\\.c$$" "^.*\\\\.cpp$$"
+  set(${PROJECT_NAME}_ClangTidy_FILES_RE
+      "^.*\\\\.cc$$"
+      "^.*\\\\.cpp$$"
+      "^.*\\\\.cxx$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
   set(${PROJECT_NAME}_ClangTidy_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")

--- a/cpp/NamingConventions.md
+++ b/cpp/NamingConventions.md
@@ -18,8 +18,8 @@ Follow [File Names](https://google.github.io/styleguide/cppguide.html#General_Na
 convention of Google C++ Style Guide but use the following extension instead:
 
 * C++ files: `.cpp`
-* C++ header: `.hpp`
-* C++ template implementations: `.ipp`
+* C++ header: `.h`
+* C++ template definitions: `.ipp`
 
 ## Use descriptive variable names
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -134,8 +134,13 @@ A list of CMake cache variables can be used to customize the code formatting:
 * `${PROJECT}_ClangFormat_OPTIONS`: additional options given to `clang-format` command.
   Default value is `""`.
 * `${PROJECT}_ClangFormat_FILES_RE`: list of regular expressions matching C/C++ filenames
-  to format. Default is:<br/>
-  `"^.*\\\\.[ch]$$" "^.*\\\\.[chi]pp$$"`
+  to format. Despite the recommended extensions of this guidelines are `.cpp`, `.h`, and `.ipp`
+  (see [Naming Conventions](./NamingConventions.md)), files with the following extensions
+  will be formatted by default:
+  * C++ implementation files: `.cpp`, `.cc`, `.cxx`, `.c`
+  * C++ header files: `.h`, `.hh`, `.hpp`, `.hxx`
+  * C++ files with template methods definitions: `.tpp`, `.txx`, `.tcc`, `.ipp`, `.ixx`, `.icc`
+
 * `${PROJECT}_ClangFormat_EXCLUDES_RE`: list of regular expressions to exclude C/C++ files
   from formatting. Default value is:<br/>
   `".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"`
@@ -193,13 +198,14 @@ It will also activate static analysis report during the compilation phase.
 
 ##### Advanced configuration
 
-A list of CMake cache variables can be used to customize static analysis:
+The following CMake cache variables can be used to customize the static analysis
+of the code:
 
 * `${PROJECT}_ClangTidy_OPTIONS`: additional options given to `clang-tidy` command.
   Default value is `""`.
 * `${PROJECT}_ClangTidy_FILES_RE`: list of regular expressions matching C/C++ filenames
   to check. Default is:<br/>
-  `"^.*\\\\.c$$" "^.*\\\\.h$$" "^.*\\\\.cpp$$" "^.*\\\\.hpp$$"`
+  `"^.*\\\\.cc$$" "^.*\\\\.cpp$$" "^.*\\\\.cxx$$"`
 * `${PROJECT}_ClangTidy_EXCLUDES_RE`: list of regular expressions to exclude C/C++ files
   from static analysis. Default value is:<br/>
   `".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"`
@@ -207,7 +213,8 @@ A list of CMake cache variables can be used to customize static analysis:
   check C/C++ code. Default value is `""`
 
 These variables are meant to be overridden inside your CMake project.
-They are CMake _CACHE_ variables whose value must be forced.
+They are CMake _CACHE_ variables whose value must be forced
+**before including this CMake project**.
 
 ##### Continuous Integration
 


### PR DESCRIPTION
* Support other C++ file extensions than the one recommended
by this coding conventions for clang-format.
* Update recommended C++ header file extension from `.hpp` to `.h`.