### PR TITLE
Allow formatting of C++ chunks with clang-format-diff

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -52,6 +52,8 @@ function(bbp_enable_clang_formatting)
       -B
       "${CMAKE_BINARY_DIR}"
       "--executable=${ClangFormat_EXECUTABLE}"
+      "--clang-format-diff-executable=${ClangFormatDiff_EXECUTABLE}"
+      "--changes-only=${${PROJECT_NAME}_FORMATTING_CPP_CHANGES_ONLY}"
       --files-re
       ${${PROJECT_NAME}_ClangFormat_FILES_RE}
       $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
@@ -184,6 +186,8 @@ bob_option(${PROJECT_NAME}_FORMATTING "Enable helpers to keep CMake and C++ code
            OFF)
 bob_input(${PROJECT_NAME}_FORMATTING_ON "all" STRING
           "Specify changeset where formatting applies (see documentation for detailed information)")
+bob_option(${PROJECT_NAME}_FORMATTING_CPP_CHANGES_ONLY
+           "Only format the modified chunks, not the entire files" OFF)
 bob_option(${PROJECT_NAME}_TEST_FORMATTING "Add CTest formatting test" OFF)
 bob_option(${PROJECT_NAME}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
 bob_option(${PROJECT_NAME}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -106,17 +106,23 @@ To enable the formatting of CMake and C++ code inside git submodules, enable the
 Use `${PROJECT}_FORMATTING_ON:STRING` CMake variable to apply formatting on a subset.
 Possible values are:
 * `all`: apply formatting on the entire repository (the default).
-* `staged`: apply formatting only on added and modified files in the git staging area.
+* `working`: apply formatting only on the git working area.
+* `staging`: apply formatting only on the git staging area.
 * `since-ref:GIT_REF`: apply formatting only on added and modified files in the commits
 since the given ref. For instance `since-ref:origin/master` is equivalent to:
    ```
    fork_point=`git merge-base --fork-point origin/master HEAD`
    git diff --name-status $fork_point | grep '^[AM]'
    ```
-* `base-branch`: an alias for `since-ref:$CHANGE_TARGET`. CHANGE_TARGET is a Jenkins
+* `base-branch`: an alias for `since-ref:$CHANGE_TARGET`. `CHANGE_TARGET` is a Jenkins
 environment variable that contains the target or base branch to which the change
 could be merged.
 * `since-rev:GIT_REV`. For instance `since-ref:fcfc8b6a`
+
+By default, a C++ file is entirely formatted.  To only reformat the lines touches
+by the set of changed defined by `${PROJECT}_FORMATTING_ON:STRING` CMake variable,
+enable the CMake variable `${PROJECT}_FORMATTING_CPP_CHANGES_ONLY:BOOL`.
+This option is ineffective when `${PROJECT}_FORMATTING_ON:STRING` equals `all`.
 
 ##### Usage
 

--- a/cpp/cmake/FindClangFormat.cmake
+++ b/cpp/cmake/FindClangFormat.cmake
@@ -99,6 +99,11 @@ if(ClangFormat_EXECUTABLE)
     else()
       set(ClangFormat_VERSION_PATCH 0)
     endif()
+
+    find_program(ClangFormatDiff_EXECUTABLE
+                 NAMES clang-format-diff-${ClangFormat_VERSION_MAJOR} clang-format-diff
+                 DOC "clang-format-diff executable")
+    mark_as_advanced(ClangFormatDiff_EXECUTABLE)
   endif()
   unset(ClangFormat_version)
 endif()

--- a/cpp/cmake/bbp-clang-format.py
+++ b/cpp/cmake/bbp-clang-format.py
@@ -2,17 +2,177 @@
 import contextlib
 import filecmp
 import functools
+import itertools
 import logging
 import os
+import os.path as osp
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
 
-from cpplib import collect_files, filter_git_modified, log_command, make_cpp_file_filter, parse_cli
+from cpplib import (
+    collect_files,
+    filter_files_outside_time_range,
+    GitDiffDelta,
+    log_command,
+    make_cpp_file_filter,
+    parse_cli,
+    pipe_processes,
+    pushd,
+    str2bool,
+)
 
 
-def do_format(cpp_file, clang_format, options):
+def file_filters_cli_options(args):
+    """
+    Rebuild file filtering command line arguments from the parsed values
+
+    Args:
+      args: parsed CLI arguments
+
+    Returns:
+      list of raw CLI options
+    """
+    result = ["-S", args.source_dir, "-B", args.binary_dir]
+    if args.git_modules:
+        result.append('--git-modules')
+    for re_opt, patterns in [
+        ("--files-re", args.files_re),
+        ("--excludes-re", args.excludes_re),
+    ]:
+        result += list(itertools.chain(*list(itertools.product([re_opt], patterns))))
+    return result
+
+
+def diff_filters_command(args):
+    """
+    Args:
+      args: parsed CLI arguments
+
+    Returns:
+      Command to execute the bbp-diff-filters.py according to the file filters given to
+      this current program
+    """
+    return [
+        sys.executable,
+        osp.join(osp.dirname(__file__), 'bbp-diff-filter.py'),
+    ] + file_filters_cli_options(args)
+
+
+def clang_format_diff_command(args, apply_changes=True):
+    """
+    Args:
+        args: parsed CLI arguments
+        apply_changes: whether clang-format-diff should apply the changes
+        on the codebase or simply output the formatted diff
+
+    Returns:
+        Command to execute clang-format-diff
+    """
+    command = [
+        args.clang_format_diff_executable,
+        "-sort-includes",
+        "-binary",
+        args.executable,
+        "-p1",
+    ]
+    if logging.root.level >= logging.INFO:
+        command.append("--verbose")
+    if apply_changes:
+        command.append("-i")
+    return command
+
+
+def compare_diffs(delta, patch, formatted_patch):
+    """
+    Compare the 2 given diff files, and print the differences to standard output
+    with `interdiff` utility (from package patchtutil).
+
+    Args:
+        delta(GitDiffDelta): a set of git changes
+        patch: path to diff file of unformatted changes
+        formatted_patch: path to diff file of changes formatted
+        with clang-format-diff utility
+
+    Returns:
+        True if files are identical, False otherwise
+    """
+    same = filecmp.cmp(patch, formatted_patch)
+    if not same:
+        logging.error(
+            "\033[1;31merror:\033[0;0m" "improper C/C++ files formatting of %s.", delta
+        )
+    interdiff = shutil.which("interdiff")
+    if interdiff:
+        subprocess.check_call([interdiff, '-U0', patch, formatted_patch])
+    else:
+        logging.warn("Can not find 'interdiff' executable")
+        logging.warn("Please install 'patchutil' package to display differences.")
+    return same
+
+
+def do_partial_format(delta, args, apply_changes=True):
+    """
+    Format the modified chunks of the C/C++ files touched by the specified set of changes
+
+    Args:
+         delta(GitDiffDelta): a set of git changes
+         args: parsed CLI arguments
+         apply_changes: whether clang-format-diff should apply the changes
+        on the codebase or simply output the formatted diff
+    """
+    with pushd(args.source_dir):
+        commands = [
+            delta.diff_command,
+            diff_filters_command(args),
+            clang_format_diff_command(args, apply_changes=apply_changes),
+        ]
+        process = pipe_processes(*commands)
+        return_code = process.wait()
+
+    if return_code != 0:
+        raise Exception("Error occurred while formatting changes")
+    return return_code == 0
+
+
+def do_partial_check(delta, args, tempfile=None):
+    """
+    Ensure that the modified chunks of the C/C++ files touched by the specified
+    set of changes are properly formatted.
+
+    Args:
+         delta(GitDiffDelta): a set of git changes
+         args: parsed CLI arguments
+         tempfile: path to a temporary file previously created
+    """
+    with pushd(args.source_dir):
+        # generate diff of specified git changes
+        with open(tempfile, 'w') as ostr:
+            proc = pipe_processes(
+                delta.diff_command, diff_filters_command(args), stdout=ostr
+            )
+            exit_status = proc.wait()
+            if exit_status != 0:
+                raise Exception(
+                    'Error occurred while executing command: %s', exit_status
+                )
+        formatted_file = tempfile + '.format'
+        with open(tempfile) as istr, open(formatted_file, 'w') as ostr:
+            # format the diff
+            command = clang_format_diff_command(args, apply_changes=False)
+            log_command(command)
+            subprocess.check_call(command, stdin=istr, stdout=ostr)
+    same = compare_diffs(delta, tempfile, formatted_file)
+    os.remove(formatted_file)
+    return same
+
+
+def do_full_format(cpp_file, clang_format, options):
+    """
+    Format all the C/C++ files of the project
+    """
     cmd = [clang_format] + options
     if "-i" not in options:
         cmd.append("-i")
@@ -21,7 +181,10 @@ def do_format(cpp_file, clang_format, options):
     return subprocess.call(cmd) == 0
 
 
-def do_check(cpp_file, clang_format, options, tempfile=None):
+def do_full_check(cpp_file, clang_format, options, tempfile=None):
+    """
+    Ensure that all the C/C++ files of the project are properly formatted
+    """
     options = [opt for opt in options if opt != "-i"]
     cmd = [clang_format] + options
     cmd.append(cpp_file)
@@ -41,7 +204,10 @@ def do_check(cpp_file, clang_format, options, tempfile=None):
 
 @contextlib.contextmanager
 def build_action_func(args):
-    action = getattr(sys.modules[__name__], "do_" + args.action)
+    if args.changes_only and args.applies_on != 'all':
+        action = getattr(sys.modules[__name__], "do_partial_" + args.action)
+    else:
+        action = getattr(sys.modules[__name__], "do_full_" + args.action)
     try:
         if args.action == "check":
             fd, path = tempfile.mkstemp()
@@ -54,7 +220,20 @@ def build_action_func(args):
 
 
 def main(**kwargs):
-    args = parse_cli(**kwargs)
+    parser_args = [
+        ("--clang-format-diff-executable", dict(help="Path to clang-format-diff")),
+        (
+            "--changes-only",
+            dict(
+                type=str2bool,
+                help="Only format modified chunks, not the entire files",
+                const=True,
+                default=False,
+                nargs="?",
+            ),
+        ),
+    ]
+    args = parse_cli(parser_args=parser_args, **kwargs)
     excludes_re = [re.compile(r) for r in args.excludes_re]
     files_re = [re.compile(r) for r in args.files_re]
     filter_cpp_file = make_cpp_file_filter(
@@ -62,8 +241,13 @@ def main(**kwargs):
     )
     with build_action_func(args) as action:
         succeeded = True
-        for cpp_file in filter_git_modified(args, collect_files(args.compile_commands_file, filter_cpp_file)):
-            succeeded &= action(cpp_file, args.executable, args.options)
+        if args.changes_only and args.applies_on != 'all':
+            succeeded = action(GitDiffDelta.from_applies_on(args.applies_on), args)
+        else:
+            for cpp_file in filter_files_outside_time_range(
+                args, collect_files(args.compile_commands_file, filter_cpp_file)
+            ):
+                succeeded &= action(cpp_file, args.executable, args.options)
     return succeeded
 
 

--- a/cpp/cmake/bbp-cmake-format.py
+++ b/cpp/cmake/bbp-cmake-format.py
@@ -11,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 
-from cpplib import filter_git_modified, log_command, parse_cli
+from cpplib import filter_files_outside_time_range, log_command, parse_cli
 
 
 def _build_excluded_dirs():
@@ -50,7 +50,7 @@ def collect_files(cmake_source_dir, cmake_binary_dir, excludes_re, cmake_files_r
         d = queue.pop()
         for f in os.listdir(d):
             p = osp.realpath(osp.join(d, f))
-            rp = p[len(cmake_source_dir):]
+            rp = p[len(cmake_source_dir) :]
             if p == cmake_binary_dir:
                 continue
             for regex in excludes_re:
@@ -131,9 +131,9 @@ def main(**kwargs):
     files_re = [re.compile(r) for r in args.files_re]
     with build_action_func(args) as action:
         succeeded = True
-        for cmake_file in filter_git_modified(args, collect_files(
-            args.source_dir, args.binary_dir, excludes_re, files_re
-        )):
+        for cmake_file in filter_files_outside_time_range(
+            args, collect_files(args.source_dir, args.binary_dir, excludes_re, files_re)
+        ):
             succeeded &= action(cmake_file, args.executable, args.options)
     return succeeded
 

--- a/cpp/cmake/bbp-diff-filter.py
+++ b/cpp/cmake/bbp-diff-filter.py
@@ -1,0 +1,60 @@
+"""
+This script reads input from a unified diff and filter its content
+according to regular expressions passed in CLI.
+
+For instance:
+
+  git diff -U0 --no-color HEAD^ | bbp-diff-filter --git-modules --files-re ".*\\.h"
+"""
+import logging
+import os
+import os.path as osp
+import re
+import sys
+
+from cpplib import parse_cli, make_cpp_file_filter
+
+
+DIFF_HEADER_PATTERNS = [
+    re.compile(pattern)
+    for pattern in ["^diff --git a/.* b/(.*)$", "^diff --git a/(.*)$"]
+]
+
+
+def main(**kwargs):
+    description = sys.modules[__name__].__doc__
+    args = parse_cli(description=description, **kwargs)
+    excludes_re = [re.compile(r) for r in args.excludes_re or []]
+    files_re = [re.compile(r) for r in args.files_re or []]
+    filter_cpp_file = make_cpp_file_filter(
+        args.source_dir, args.binary_dir, excludes_re, files_re
+    )
+    try:
+        line = input()
+        while True:
+            filename = None
+            for pattern in DIFF_HEADER_PATTERNS:
+                match = pattern.match(line)
+                if match:
+                    filename = match.group(0)
+                    break
+            if filename:
+                file = osp.realpath(osp.join(args.source_dir, filename))
+                if not filter_cpp_file(file):
+                    print(line)
+                    logging.info(line)
+                    line = input()
+                    while not line.startswith("diff --git"):
+                        print(line)
+                        line = input()
+                    continue
+            line = input()
+    except EOFError:
+        pass
+    return True
+
+
+if __name__ == '__main__':
+    level = logging.INFO if 'VERBOSE' in os.environ else logging.WARN
+    logging.basicConfig(level=level, format="%(message)s")
+    sys.exit(0 if main() else 1)

--- a/cpp/cmake/bbp-setup-pre-commit-config.py
+++ b/cpp/cmake/bbp-setup-pre-commit-config.py
@@ -2,10 +2,13 @@ import argparse
 import os.path as osp
 
 import yaml
+
 try:
     from yaml import CLoader as Loader
 except ImportError:
     from yaml import Loader
+
+from cpplib import str2bool
 
 
 HPC_PRE_COMMITS_REPO_URL = "https://github.com/BlueBrain/hpc-pre-commits"
@@ -15,15 +18,6 @@ DEFAULT_HPC_PRE_COMMIT_REPO = dict(
 CHECK_CLANG_FORMAT_HOOK_ID = "check-clang-format"
 CHECK_CMAKE_FORMAT_HOOK_ID = "check-cmake-format"
 CHECK_CLANG_TIDY_HOOK_ID = "clang-tidy"
-
-
-def str2bool(v):
-    if v.lower() in ("yes", "true", "t", "y", "1", "on"):
-        return True
-    elif v.lower() in ("no", "false", "f", "n", "0", "off"):
-        return False
-    else:
-        raise argparse.ArgumentTypeError("Boolean value expected.")
 
 
 def _parse_cli(args=None):
@@ -37,7 +31,8 @@ def _parse_cli(args=None):
         nargs="?",
     )
     parser.add_argument(
-        "-f", "--force",
+        "-f",
+        "--force",
         type=str2bool,
         help="Force regenerating pre-commit hooks",
         default=False,


### PR DESCRIPTION
 New ${PROJECT_NAME}_FORMATTING_CPP_CHANGES_ONLY:BOOL=False CMake variable
    
By default, a C++ file is entirely formatted. Enable this variable to
only reformat the lines touches by the set of changed defined by
`${PROJECT}_FORMATTING_ON:STRING` CMake variable.
This option is ineffective when `${PROJECT}_FORMATTING_ON:STRING` equals `all`.
