### PR TITLE
Add capability to overwrite the default clang-tidy configuration

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -166,7 +166,22 @@ function(bbp_enable_static_analysis)
       CACHE STRING "list of CMake targets to build before formatting C/C++ code")
   mark_as_advanced(${PROJECT_NAME}_ClangTidy_OPTIONS ${PROJECT_NAME}_ClangTidy_FILES_RE
                    ${PROJECT_NAME}_ClangTidy_EXCLUDES_RE)
-  configure_file(.clang-tidy ${PROJECT_SOURCE_DIR})
+  execute_process(COMMAND git ls-files --error-unmatch .clang-tidy
+                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                  RESULT_VARIABLE is_clang_tidy_config_tracked
+                  ERROR_QUIET)
+  if(NOT is_clang_tidy_config_tracked EQUAL 0)
+    if(EXISTS ${PROJECT_SOURCE_DIR}/.clang-tidy.changes)
+      execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py"
+                              merge-clang-tidy-config "${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy"
+                              "${PROJECT_SOURCE_DIR}/.clang-tidy.changes"
+                              "${PROJECT_SOURCE_DIR}/.clang-tidy")
+    else()
+      configure_file(.clang-tidy ${PROJECT_SOURCE_DIR} COPYONLY)
+    endif()
+  endif()
+  unset(is_clang_tidy_config_tracked)
+
   set(clang_tidy_command_prefix
       ${PYTHON_EXECUTABLE}
       "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-clang-tidy.py"

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -183,11 +183,11 @@ during code formatting:
 ##### Custom ClangFormat configuration
 
 These coding conventions come with a predefined configuration of ClangFormat that
-will be copied in the top directory of the project.
+is by default copied in the top directory of the project.
 
 It is recommended to not add this `.clang-format` to git so that it is fully
 driven by this project. It will get updated along with the evolution of these
-guidelines. Thus it is recommended to ignore file `.clang-format` by adding
+guidelines. Thus it is recommended to inform git to ignore this file by adding
 it to the top `.gitignore`.
 
 A project can however override the predefined configuration of ClangFormat
@@ -237,6 +237,23 @@ of the code:
 These variables are meant to be overridden inside your CMake project.
 They are CMake _CACHE_ variables whose value must be forced
 **before including this CMake project**.
+
+##### Custom ClangTidy configuration
+
+These coding conventions come with a `.clang-tidy` file providing a predefined
+list of ClangTidy checks. By default, this file is copied in the top directory
+of the project.
+
+It is recommended to not add this `.clang-tidy` to git so that it is fully
+driven by this project. It will get updated along with the evolution of these
+guidelines. Thus it is recommended to inform git to ignore this file by adding
+it to the top `.gitignore`.
+
+A project can however override the predefined configuration of ClangFormat
+in two ways:
+1. Create a `.clang-tidy.changes` containing only the required modifications.
+1. Add `.clang-tidy` to the git repository. This project will never try
+to modify it.
 
 ##### Continuous Integration
 


### PR DESCRIPTION
Either add `.clang-tidy` to the repository to not use the
one from the coding conventions or add `.clang-tidy.changes`
to the repository containing only the configuration changes.

The "Checks" key is properly merged.