### PR TITLE
Add an option to set the option prefix

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,28 +1,37 @@
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} PARENT_SCOPE)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON PARENT_SCOPE)
+set(CMAKE_MODULE_PATH
+    ${CMAKE_MODULE_PATH}
+    PARENT_SCOPE)
+set(CMAKE_EXPORT_COMPILE_COMMANDS
+    ON
+    PARENT_SCOPE)
+if(NOT BBPCC_VAR_PREFIX)
+  set(BBPCC_VAR_PREFIX "${PROJECT_NAME}")
+  set(BBPCC_VAR_PREFIX "${PROJECT_NAME}" PARENT_SCOPE)
+endif(NOT BBPCC_VAR_PREFIX)
 include(cmake/bob.cmake)
 
 function(bbp_enable_precommit)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(PreCommit REQUIRED)
   execute_process(COMMAND ${PreCommit_EXECUTABLE} install)
-  execute_process(COMMAND ${PYTHON_EXECUTABLE}
-                          "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py" --force
-                          ${${PROJECT_PREFIX}_PRECOMMIT_REGEN} --clang-format
-                          ${${PROJECT_PREFIX}_FORMATTING} --cmake-format ${${PROJECT_PREFIX}_FORMATTING}
-                          --clang-tidy ${${PROJECT_PREFIX}_STATIC_ANALYSIS} ${CMAKE_SOURCE_DIR}
-                          ${CMAKE_BINARY_DIR})
+  execute_process(
+    COMMAND
+      ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
+      --force ${${BBPCC_VAR_PREFIX}_PRECOMMIT_REGEN} --clang-format
+      ${${BBPCC_VAR_PREFIX}_FORMATTING} --cmake-format ${${BBPCC_VAR_PREFIX}_FORMATTING}
+      --clang-tidy ${${BBPCC_VAR_PREFIX}_STATIC_ANALYSIS} ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   add_custom_target(git-pre-commits ${PreCommit_EXECUTABLE} run --all-files)
 endfunction(bbp_enable_precommit)
 
 function(bbp_disable_precommit)
   if(EXISTS ${CMAKE_SOURCE_DIR}/.pre-commit-config.yaml)
     find_package(PythonInterp 3.5 REQUIRED)
-    execute_process(COMMAND ${PYTHON_EXECUTABLE}
-                            "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
-                            --clang-format off --cmake-format off --clang-tidy off
-                            ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+    execute_process(
+      COMMAND
+        ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
+        --clang-format off --cmake-format off --clang-tidy off ${CMAKE_SOURCE_DIR}
+        ${CMAKE_BINARY_DIR})
   endif()
 endfunction(bbp_disable_precommit)
 
@@ -34,41 +43,42 @@ function(bbp_enable_clang_formatting)
     return()
   endif()
   if(ClangFormat_VERSION_MAJOR GREATER 6 AND ClangFormat_VERSION_MAJOR LESS 10)
-    set(${PROJECT_PREFIX}_ClangFormat_CONFIG_FILE .clang-format-${ClangFormat_VERSION_MAJOR})
+    set(${BBPCC_VAR_PREFIX}_ClangFormat_CONFIG_FILE .clang-format-${ClangFormat_VERSION_MAJOR})
   else()
     message(
       SEND_ERROR
         "Unsupported Clang-Format version ${ClangFormat_VERSION}. Supported versions are 7, 8, or 9"
-      )
+    )
   endif()
 
-  set(${PROJECT_PREFIX}_ClangFormat_OPTIONS "" CACHE STRING "clang-format command options")
-  set(${PROJECT_PREFIX}_ClangFormat_FILES_RE
-      "^.*\\\\.cc?$$"
-      "^.*\\\\.hh?$$"
-      "^.*\\\\.[it]cc$$"
-      "^.*\\\\.[chit]pp$$"
-      "^.*\\\\.[chit]xx$$"
+  set(${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS
+      ""
+      CACHE STRING "clang-format command options")
+  set(${BBPCC_VAR_PREFIX}_ClangFormat_FILES_RE
+      "^.*\\\\.cc?$$" "^.*\\\\.hh?$$" "^.*\\\\.[it]cc$$" "^.*\\\\.[chit]pp$$" "^.*\\\\.[chit]xx$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
-  set(${PROJECT_PREFIX}_ClangFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
+  set(${BBPCC_VAR_PREFIX}_ClangFormat_EXCLUDES_RE
+      ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")
-  set(${PROJECT_PREFIX}_ClangFormat_DEPENDENCIES ""
+  set(${BBPCC_VAR_PREFIX}_ClangFormat_DEPENDENCIES
+      ""
       CACHE STRING "list of CMake targets to build before formatting C/C++ code")
-  mark_as_advanced(${PROJECT_PREFIX}_ClangFormat_OPTIONS ${PROJECT_PREFIX}_ClangFormat_FILES_RE
-                   ${PROJECT_PREFIX}_ClangFormat_EXCLUDES_RE)
-  execute_process(COMMAND git ls-files --error-unmatch .clang-format
-                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                  RESULT_VARIABLE is_clang_format_config_tracked
-                  ERROR_QUIET)
+  mark_as_advanced(${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS ${BBPCC_VAR_PREFIX}_ClangFormat_FILES_RE
+                   ${BBPCC_VAR_PREFIX}_ClangFormat_EXCLUDES_RE)
+  execute_process(
+    COMMAND git ls-files --error-unmatch .clang-format
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE is_clang_format_config_tracked
+    ERROR_QUIET)
   if(NOT is_clang_format_config_tracked EQUAL 0)
     if(EXISTS ${PROJECT_SOURCE_DIR}/.clang-format.changes)
-      execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py"
-                              merge-yaml "${CMAKE_CURRENT_SOURCE_DIR}/${${PROJECT_PREFIX}_ClangFormat_CONFIG_FILE}"
-                              "${PROJECT_SOURCE_DIR}/.clang-format.changes"
-                              "${PROJECT_SOURCE_DIR}/.clang-format")
+      execute_process(
+        COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py" merge-yaml
+                "${CMAKE_CURRENT_SOURCE_DIR}/${${BBPCC_VAR_PREFIX}_ClangFormat_CONFIG_FILE}"
+                "${PROJECT_SOURCE_DIR}/.clang-format.changes" "${PROJECT_SOURCE_DIR}/.clang-format")
     else()
-      configure_file(${${PROJECT_PREFIX}_ClangFormat_CONFIG_FILE} ${PROJECT_SOURCE_DIR}/.clang-format
-                     COPYONLY)
+      configure_file(${${BBPCC_VAR_PREFIX}_ClangFormat_CONFIG_FILE}
+                     ${PROJECT_SOURCE_DIR}/.clang-format COPYONLY)
     endif()
   endif()
   unset(is_clang_format_config_tracked)
@@ -82,60 +92,57 @@ function(bbp_enable_clang_formatting)
       "${CMAKE_BINARY_DIR}"
       "--executable=${ClangFormat_EXECUTABLE}"
       "--clang-format-diff-executable=${ClangFormatDiff_EXECUTABLE}"
-      "--changes-only=${${PROJECT_PREFIX}_FORMATTING_CPP_CHANGES_ONLY}"
+      "--changes-only=${${BBPCC_VAR_PREFIX}_FORMATTING_CPP_CHANGES_ONLY}"
       --files-re
-      ${${PROJECT_PREFIX}_ClangFormat_FILES_RE}
-      $<$<BOOL:${PROJECT_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      ${${BBPCC_VAR_PREFIX}_ClangFormat_FILES_RE}
+      $<$<BOOL:${BBPCC_VAR_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${PROJECT_PREFIX}_ClangFormat_EXCLUDES_RE}
+      ${${BBPCC_VAR_PREFIX}_ClangFormat_EXCLUDES_RE}
       -p
       ${CMAKE_BINARY_DIR}/compile_commands.json
-      --applies-on=${${PROJECT_PREFIX}_FORMATTING_ON})
-  add_custom_target(clang-format
-                    ${clang_format_command_prefix}
-                    --action
-                    format
-                    --
-                    "${${PROJECT_PREFIX}_ClangFormat_OPTIONS}")
-  add_custom_target(check-clang-format
-                    ${clang_format_command_prefix}
-                    --action
-                    check
-                    --
-                    "${${PROJECT_PREFIX}_ClangFormat_OPTIONS}")
-  if(${PROJECT_PREFIX}_TEST_FORMATTING)
+      --applies-on=${${BBPCC_VAR_PREFIX}_FORMATTING_ON})
+  add_custom_target(clang-format ${clang_format_command_prefix} --action format --
+                    "${${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS}")
+  add_custom_target(check-clang-format ${clang_format_command_prefix} --action check --
+                    "${${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS}")
+  if(${BBPCC_VAR_PREFIX}_TEST_FORMATTING)
     add_test(NAME ClangFormat
-             COMMAND ${clang_format_command_prefix}
-                     --action check
-                     --make-unescape-re
-                     -- "${${PROJECT_PREFIX}_ClangFormat_OPTIONS}")
+             COMMAND ${clang_format_command_prefix} --action check --make-unescape-re --
+                     "${${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS}")
   endif()
-  if(${PROJECT_PREFIX}_ClangFormat_DEPENDENCIES)
-    add_dependencies(clang-format ${${PROJECT_PREFIX}_ClangFormat_DEPENDENCIES})
-    add_dependencies(check-clang-format ${${PROJECT_PREFIX}_ClangFormat_DEPENDENCIES})
+  if(${BBPCC_VAR_PREFIX}_ClangFormat_DEPENDENCIES)
+    add_dependencies(clang-format ${${BBPCC_VAR_PREFIX}_ClangFormat_DEPENDENCIES})
+    add_dependencies(check-clang-format ${${BBPCC_VAR_PREFIX}_ClangFormat_DEPENDENCIES})
   endif()
 endfunction(bbp_enable_clang_formatting)
 
 function(bbp_enable_cmake_formatting)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(CMakeFormat 0.6.0 EXACT REQUIRED)
-  set(${PROJECT_PREFIX}_CMakeFormat_OPTIONS "" CACHE STRING "cmake-format options")
-  set(${PROJECT_PREFIX}_CMakeFormat_FILES_RE "^.*\\\\.cmake$$" "^.*CMakeLists.txt$$"
+  set(${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS
+      ""
+      CACHE STRING "cmake-format options")
+  set(${BBPCC_VAR_PREFIX}_CMakeFormat_FILES_RE
+      "^.*\\\\.cmake$$" "^.*CMakeLists.txt$$"
       CACHE STRING "List of regular expressions matching CMake files")
-  set(${PROJECT_PREFIX}_CMakeFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
+  set(${BBPCC_VAR_PREFIX}_CMakeFormat_EXCLUDES_RE
+      ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude CMake files from formatting")
-  mark_as_advanced(${PROJECT_PREFIX}_CMakeFormat_OPTIONS ${PROJECT_PREFIX}_CMakeFormat_FILES_RE
-                   ${PROJECT_PREFIX}_CMakeFormat_EXCLUDES_RE)
-  execute_process(COMMAND git ls-files --error-unmatch .cmake-format
-          WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-          RESULT_VARIABLE is_cmake_format_config_tracked
-          ERROR_QUIET)
+  mark_as_advanced(${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS ${BBPCC_VAR_PREFIX}_CMakeFormat_FILES_RE
+                   ${BBPCC_VAR_PREFIX}_CMakeFormat_EXCLUDES_RE)
+  execute_process(
+    COMMAND git ls-files --error-unmatch .cmake-format
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE is_cmake_format_config_tracked
+    ERROR_QUIET)
   if(NOT is_cmake_format_config_tracked EQUAL 0)
     if(EXISTS ${PROJECT_SOURCE_DIR}/.cmake-format.changes.yaml)
-      execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py"
-              merge-yaml "${CMAKE_CURRENT_SOURCE_DIR}/.cmake-format.yaml"
-              "${PROJECT_SOURCE_DIR}/.cmake-format.changes.yaml"
-              "${PROJECT_SOURCE_DIR}/.cmake-format.yaml")
+      execute_process(
+        COMMAND
+          ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py" merge-yaml
+          "${CMAKE_CURRENT_SOURCE_DIR}/.cmake-format.yaml"
+          "${PROJECT_SOURCE_DIR}/.cmake-format.changes.yaml"
+          "${PROJECT_SOURCE_DIR}/.cmake-format.yaml")
     else()
       configure_file(.cmake-format.yaml ${PROJECT_SOURCE_DIR} COPYONLY)
     endif()
@@ -149,29 +156,19 @@ function(bbp_enable_cmake_formatting)
       "${CMAKE_BINARY_DIR}"
       "--executable=${CMakeFormat_EXECUTABLE}"
       --files-re
-      ${${PROJECT_PREFIX}_CMakeFormat_FILES_RE}
-      $<$<BOOL:${PROJECT_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      ${${BBPCC_VAR_PREFIX}_CMakeFormat_FILES_RE}
+      $<$<BOOL:${BBPCC_VAR_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${PROJECT_PREFIX}_CMakeFormat_EXCLUDES_RE}
-      --applies-on=${${PROJECT_PREFIX}_FORMATTING_ON})
-  add_custom_target(cmake-format
-                    ${cmake_format_command_prefix}
-                    --action
-                    format
-                    --
-                    "${${PROJECT_PREFIX}_CMakeFormat_OPTIONS}")
-  add_custom_target(check-cmake-format
-                    ${cmake_format_command_prefix}
-                    --action
-                    check
-                    --
-                    ${${PROJECT_PREFIX}_CMakeFormat_OPTIONS})
-  if(${PROJECT_PREFIX}_TEST_FORMATTING)
+      ${${BBPCC_VAR_PREFIX}_CMakeFormat_EXCLUDES_RE}
+      --applies-on=${${BBPCC_VAR_PREFIX}_FORMATTING_ON})
+  add_custom_target(cmake-format ${cmake_format_command_prefix} --action format --
+                    "${${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS}")
+  add_custom_target(check-cmake-format ${cmake_format_command_prefix} --action check --
+                    ${${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS})
+  if(${BBPCC_VAR_PREFIX}_TEST_FORMATTING)
     add_test(NAME CMakeFormat
-             COMMAND ${cmake_format_command_prefix}
-                     --action check
-                     --make-unescape-re
-                     -- ${${PROJECT_PREFIX}_CMakeFormat_OPTIONS})
+             COMMAND ${cmake_format_command_prefix} --action check --make-unescape-re --
+                     ${${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS})
   endif()
 
 endfunction(bbp_enable_cmake_formatting)
@@ -179,30 +176,32 @@ endfunction(bbp_enable_cmake_formatting)
 function(bbp_enable_static_analysis)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(ClangTidy 7 EXACT REQUIRED)
-  set(${PROJECT_PREFIX}_ClangTidy_OPTIONS -extra-arg=-Wno-unknown-warning-option
+  set(${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS
+      -extra-arg=-Wno-unknown-warning-option
       CACHE STRING "clang-tidy command options")
-  mark_as_advanced(${PROJECT_PREFIX}_ClangTidy_OPTIONS)
-  set(${PROJECT_PREFIX}_ClangTidy_FILES_RE
-      "^.*\\\\.cc$$"
-      "^.*\\\\.cpp$$"
-      "^.*\\\\.cxx$$"
+  mark_as_advanced(${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS)
+  set(${BBPCC_VAR_PREFIX}_ClangTidy_FILES_RE
+      "^.*\\\\.cc$$" "^.*\\\\.cpp$$" "^.*\\\\.cxx$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
-  set(${PROJECT_PREFIX}_ClangTidy_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
+  set(${BBPCC_VAR_PREFIX}_ClangTidy_EXCLUDES_RE
+      ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")
-  set(${PROJECT_PREFIX}_ClangTidy_DEPENDENCIES ""
+  set(${BBPCC_VAR_PREFIX}_ClangTidy_DEPENDENCIES
+      ""
       CACHE STRING "list of CMake targets to build before formatting C/C++ code")
-  mark_as_advanced(${PROJECT_PREFIX}_ClangTidy_OPTIONS ${PROJECT_PREFIX}_ClangTidy_FILES_RE
-                   ${PROJECT_PREFIX}_ClangTidy_EXCLUDES_RE)
-  execute_process(COMMAND git ls-files --error-unmatch .clang-tidy
-                  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                  RESULT_VARIABLE is_clang_tidy_config_tracked
-                  ERROR_QUIET)
+  mark_as_advanced(${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS ${BBPCC_VAR_PREFIX}_ClangTidy_FILES_RE
+                   ${BBPCC_VAR_PREFIX}_ClangTidy_EXCLUDES_RE)
+  execute_process(
+    COMMAND git ls-files --error-unmatch .clang-tidy
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE is_clang_tidy_config_tracked
+    ERROR_QUIET)
   if(NOT is_clang_tidy_config_tracked EQUAL 0)
     if(EXISTS ${PROJECT_SOURCE_DIR}/.clang-tidy.changes)
-      execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py"
-                              merge-clang-tidy-config "${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy"
-                              "${PROJECT_SOURCE_DIR}/.clang-tidy.changes"
-                              "${PROJECT_SOURCE_DIR}/.clang-tidy")
+      execute_process(
+        COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py"
+                merge-clang-tidy-config "${CMAKE_CURRENT_SOURCE_DIR}/.clang-tidy"
+                "${PROJECT_SOURCE_DIR}/.clang-tidy.changes" "${PROJECT_SOURCE_DIR}/.clang-tidy")
     else()
       configure_file(.clang-tidy ${PROJECT_SOURCE_DIR} COPYONLY)
     endif()
@@ -218,78 +217,68 @@ function(bbp_enable_static_analysis)
       "${CMAKE_BINARY_DIR}"
       "--executable=${ClangTidy_EXECUTABLE}"
       --files-re
-      "${${PROJECT_PREFIX}_ClangTidy_FILES_RE}"
-      $<$<BOOL:${PROJECT_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      "${${BBPCC_VAR_PREFIX}_ClangTidy_FILES_RE}"
+      $<$<BOOL:${BBPCC_VAR_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${PROJECT_PREFIX}_ClangTidy_EXCLUDES_RE}
+      ${${BBPCC_VAR_PREFIX}_ClangTidy_EXCLUDES_RE}
       -p
       ${CMAKE_BINARY_DIR}/compile_commands.json
       --action
       check)
-  add_custom_target(clang-tidy ${clang_tidy_command_prefix} -- ${${PROJECT_PREFIX}_ClangTidy_OPTIONS})
-  if(${PROJECT_PREFIX}_TEST_STATIC_ANALYSIS)
-    add_test(NAME ClangTidy
-             COMMAND ${clang_tidy_command_prefix}
-                     --make-unescape-re
-                     -- ${${PROJECT_PREFIX}_ClangTidy_OPTIONS})
+  add_custom_target(clang-tidy ${clang_tidy_command_prefix} --
+                    ${${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS})
+  if(${BBPCC_VAR_PREFIX}_TEST_STATIC_ANALYSIS)
+    add_test(NAME ClangTidy COMMAND ${clang_tidy_command_prefix} --make-unescape-re --
+                                    ${${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS})
   endif()
-  if(${PROJECT_PREFIX}_ClangTidy_DEPENDENCIES)
-    add_dependencies(clang-tidy ${${PROJECT_PREFIX}_ClangTidy_DEPENDENCIES})
+  if(${BBPCC_VAR_PREFIX}_ClangTidy_DEPENDENCIES)
+    add_dependencies(clang-tidy ${${BBPCC_VAR_PREFIX}_ClangTidy_DEPENDENCIES})
   endif()
 
 endfunction(bbp_enable_static_analysis)
 
-bob_input(${PROJECT_NAME}_CODING_CONV_PREFIX
-          "${PROJECT_NAME}"
-          STRING
-          "Override coding conventions options prefix (default: PROJECT_NAME)")
-set(PROJECT_PREFIX "${${PROJECT_NAME}_CODING_CONV_PREFIX}")
-
-bob_option(${PROJECT_PREFIX}_FORMATTING "Enable helpers to keep CMake and C++ code properly formatted"
-           OFF)
-bob_input(${PROJECT_PREFIX}_FORMATTING_ON
-          "all"
-          STRING
+bob_option(${BBPCC_VAR_PREFIX}_FORMATTING
+           "Enable helpers to keep CMake and C++ code properly formatted" OFF)
+bob_input(${BBPCC_VAR_PREFIX}_FORMATTING_ON "all" STRING
           "Specify changeset where formatting applies (see documentation for detailed information)")
-bob_option(${PROJECT_PREFIX}_FORMATTING_CPP_CHANGES_ONLY
+bob_option(${BBPCC_VAR_PREFIX}_FORMATTING_CPP_CHANGES_ONLY
            "Only format the modified chunks, not the entire files" OFF)
-bob_option(${PROJECT_PREFIX}_TEST_FORMATTING "Add CTest formatting test" OFF)
-bob_option(${PROJECT_PREFIX}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
-bob_option(${PROJECT_PREFIX}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)
-bob_option(${PROJECT_PREFIX}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted" OFF)
+bob_option(${BBPCC_VAR_PREFIX}_TEST_FORMATTING "Add CTest formatting test" OFF)
+bob_option(${BBPCC_VAR_PREFIX}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
+bob_option(${BBPCC_VAR_PREFIX}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)
+bob_option(${BBPCC_VAR_PREFIX}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted"
+           OFF)
 
-bob_option(${PROJECT_PREFIX}_PRECOMMIT "Enable automatic checks before git commits" OFF)
-bob_option(${PROJECT_PREFIX}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
+bob_option(${BBPCC_VAR_PREFIX}_PRECOMMIT "Enable automatic checks before git commits" OFF)
+bob_option(${BBPCC_VAR_PREFIX}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
 
-bob_option(${PROJECT_PREFIX}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
-bob_option(${PROJECT_PREFIX}_TEST_STATIC_ANALYSIS "Add CTest static analysis test" OFF)
+bob_option(${BBPCC_VAR_PREFIX}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
+bob_option(${BBPCC_VAR_PREFIX}_TEST_STATIC_ANALYSIS "Add CTest static analysis test" OFF)
 
-if(${PROJECT_PREFIX}_CLANG_FORMAT)
+if(${BBPCC_VAR_PREFIX}_CLANG_FORMAT)
   bbp_enable_clang_formatting()
-endif(${PROJECT_PREFIX}_CLANG_FORMAT)
+endif(${BBPCC_VAR_PREFIX}_CLANG_FORMAT)
 
-if(${PROJECT_PREFIX}_CMAKE_FORMAT)
+if(${BBPCC_VAR_PREFIX}_CMAKE_FORMAT)
   bbp_enable_cmake_formatting()
-endif(${PROJECT_PREFIX}_CMAKE_FORMAT)
+endif(${BBPCC_VAR_PREFIX}_CMAKE_FORMAT)
 
-if(${PROJECT_PREFIX}_FORMATTING)
+if(${BBPCC_VAR_PREFIX}_FORMATTING)
   bbp_enable_clang_formatting()
   bbp_enable_cmake_formatting()
-endif(${PROJECT_PREFIX}_FORMATTING)
+endif(${BBPCC_VAR_PREFIX}_FORMATTING)
 
-if(${PROJECT_PREFIX}_PRECOMMIT)
+if(${BBPCC_VAR_PREFIX}_PRECOMMIT)
   bbp_enable_precommit()
-else(${PROJECT_PREFIX}_PRECOMMIT)
+else(${BBPCC_VAR_PREFIX}_PRECOMMIT)
   bbp_disable_precommit()
-endif(${PROJECT_PREFIX}_PRECOMMIT)
+endif(${BBPCC_VAR_PREFIX}_PRECOMMIT)
 
-if(${PROJECT_PREFIX}_STATIC_ANALYSIS)
+if(${BBPCC_VAR_PREFIX}_STATIC_ANALYSIS)
   cmake_minimum_required(VERSION 3.6)
   bbp_enable_static_analysis()
   set(CMAKE_CXX_CLANG_TIDY
-      "${ClangTidy_EXECUTABLE}"
-      -p
-      "${CMAKE_BINARY_DIR}/compile_commands.json"
-      ${${PROJECT_PREFIX}_ClangTidy_OPTIONS}
+      "${ClangTidy_EXECUTABLE}" -p "${CMAKE_BINARY_DIR}/compile_commands.json"
+      ${${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS}
       PARENT_SCOPE)
-endif(${PROJECT_PREFIX}_STATIC_ANALYSIS)
+endif(${BBPCC_VAR_PREFIX}_STATIC_ANALYSIS)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -9,9 +9,9 @@ function(bbp_enable_precommit)
   execute_process(COMMAND ${PreCommit_EXECUTABLE} install)
   execute_process(COMMAND ${PYTHON_EXECUTABLE}
                           "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py" --force
-                          ${${PROJECT_NAME}_PRECOMMIT_REGEN} --clang-format
-                          ${${PROJECT_NAME}_FORMATTING} --cmake-format ${${PROJECT_NAME}_FORMATTING}
-                          --clang-tidy ${${PROJECT_NAME}_STATIC_ANALYSIS} ${CMAKE_SOURCE_DIR}
+                          ${${PROJECT_PREFIX}_PRECOMMIT_REGEN} --clang-format
+                          ${${PROJECT_PREFIX}_FORMATTING} --cmake-format ${${PROJECT_PREFIX}_FORMATTING}
+                          --clang-tidy ${${PROJECT_PREFIX}_STATIC_ANALYSIS} ${CMAKE_SOURCE_DIR}
                           ${CMAKE_BINARY_DIR})
   add_custom_target(git-pre-commits ${PreCommit_EXECUTABLE} run --all-files)
 endfunction(bbp_enable_precommit)
@@ -34,7 +34,7 @@ function(bbp_enable_clang_formatting)
     return()
   endif()
   if(ClangFormat_VERSION_MAJOR GREATER 6 AND ClangFormat_VERSION_MAJOR LESS 10)
-    set(${PROJECT_NAME}_ClangFormat_CONFIG_FILE .clang-format-${ClangFormat_VERSION_MAJOR})
+    set(${PROJECT_PREFIX}_ClangFormat_CONFIG_FILE .clang-format-${ClangFormat_VERSION_MAJOR})
   else()
     message(
       SEND_ERROR
@@ -42,20 +42,20 @@ function(bbp_enable_clang_formatting)
       )
   endif()
 
-  set(${PROJECT_NAME}_ClangFormat_OPTIONS "" CACHE STRING "clang-format command options")
-  set(${PROJECT_NAME}_ClangFormat_FILES_RE
+  set(${PROJECT_PREFIX}_ClangFormat_OPTIONS "" CACHE STRING "clang-format command options")
+  set(${PROJECT_PREFIX}_ClangFormat_FILES_RE
       "^.*\\\\.cc?$$"
       "^.*\\\\.hh?$$"
       "^.*\\\\.[it]cc$$"
       "^.*\\\\.[chit]pp$$"
       "^.*\\\\.[chit]xx$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
-  set(${PROJECT_NAME}_ClangFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
+  set(${PROJECT_PREFIX}_ClangFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")
-  set(${PROJECT_NAME}_ClangFormat_DEPENDENCIES ""
+  set(${PROJECT_PREFIX}_ClangFormat_DEPENDENCIES ""
       CACHE STRING "list of CMake targets to build before formatting C/C++ code")
-  mark_as_advanced(${PROJECT_NAME}_ClangFormat_OPTIONS ${PROJECT_NAME}_ClangFormat_FILES_RE
-                   ${PROJECT_NAME}_ClangFormat_EXCLUDES_RE)
+  mark_as_advanced(${PROJECT_PREFIX}_ClangFormat_OPTIONS ${PROJECT_PREFIX}_ClangFormat_FILES_RE
+                   ${PROJECT_PREFIX}_ClangFormat_EXCLUDES_RE)
   execute_process(COMMAND git ls-files --error-unmatch .clang-format
                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                   RESULT_VARIABLE is_clang_format_config_tracked
@@ -63,11 +63,11 @@ function(bbp_enable_clang_formatting)
   if(NOT is_clang_format_config_tracked EQUAL 0)
     if(EXISTS ${PROJECT_SOURCE_DIR}/.clang-format.changes)
       execute_process(COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py"
-                              merge-yaml "${CMAKE_CURRENT_SOURCE_DIR}/${${PROJECT_NAME}_ClangFormat_CONFIG_FILE}"
+                              merge-yaml "${CMAKE_CURRENT_SOURCE_DIR}/${${PROJECT_PREFIX}_ClangFormat_CONFIG_FILE}"
                               "${PROJECT_SOURCE_DIR}/.clang-format.changes"
                               "${PROJECT_SOURCE_DIR}/.clang-format")
     else()
-      configure_file(${${PROJECT_NAME}_ClangFormat_CONFIG_FILE} ${PROJECT_SOURCE_DIR}/.clang-format
+      configure_file(${${PROJECT_PREFIX}_ClangFormat_CONFIG_FILE} ${PROJECT_SOURCE_DIR}/.clang-format
                      COPYONLY)
     endif()
   endif()
@@ -82,50 +82,50 @@ function(bbp_enable_clang_formatting)
       "${CMAKE_BINARY_DIR}"
       "--executable=${ClangFormat_EXECUTABLE}"
       "--clang-format-diff-executable=${ClangFormatDiff_EXECUTABLE}"
-      "--changes-only=${${PROJECT_NAME}_FORMATTING_CPP_CHANGES_ONLY}"
+      "--changes-only=${${PROJECT_PREFIX}_FORMATTING_CPP_CHANGES_ONLY}"
       --files-re
-      ${${PROJECT_NAME}_ClangFormat_FILES_RE}
-      $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      ${${PROJECT_PREFIX}_ClangFormat_FILES_RE}
+      $<$<BOOL:${PROJECT_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${PROJECT_NAME}_ClangFormat_EXCLUDES_RE}
+      ${${PROJECT_PREFIX}_ClangFormat_EXCLUDES_RE}
       -p
       ${CMAKE_BINARY_DIR}/compile_commands.json
-      --applies-on=${${PROJECT_NAME}_FORMATTING_ON})
+      --applies-on=${${PROJECT_PREFIX}_FORMATTING_ON})
   add_custom_target(clang-format
                     ${clang_format_command_prefix}
                     --action
                     format
                     --
-                    "${${PROJECT_NAME}_ClangFormat_OPTIONS}")
+                    "${${PROJECT_PREFIX}_ClangFormat_OPTIONS}")
   add_custom_target(check-clang-format
                     ${clang_format_command_prefix}
                     --action
                     check
                     --
-                    "${${PROJECT_NAME}_ClangFormat_OPTIONS}")
-  if(${PROJECT_NAME}_TEST_FORMATTING)
+                    "${${PROJECT_PREFIX}_ClangFormat_OPTIONS}")
+  if(${PROJECT_PREFIX}_TEST_FORMATTING)
     add_test(NAME ClangFormat
              COMMAND ${clang_format_command_prefix}
                      --action check
                      --make-unescape-re
-                     -- "${${PROJECT_NAME}_ClangFormat_OPTIONS}")
+                     -- "${${PROJECT_PREFIX}_ClangFormat_OPTIONS}")
   endif()
-  if(${PROJECT_NAME}_ClangFormat_DEPENDENCIES)
-    add_dependencies(clang-format ${${PROJECT_NAME}_ClangFormat_DEPENDENCIES})
-    add_dependencies(check-clang-format ${${PROJECT_NAME}_ClangFormat_DEPENDENCIES})
+  if(${PROJECT_PREFIX}_ClangFormat_DEPENDENCIES)
+    add_dependencies(clang-format ${${PROJECT_PREFIX}_ClangFormat_DEPENDENCIES})
+    add_dependencies(check-clang-format ${${PROJECT_PREFIX}_ClangFormat_DEPENDENCIES})
   endif()
 endfunction(bbp_enable_clang_formatting)
 
 function(bbp_enable_cmake_formatting)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(CMakeFormat 0.6.0 EXACT REQUIRED)
-  set(${PROJECT_NAME}_CMakeFormat_OPTIONS "" CACHE STRING "cmake-format options")
-  set(${PROJECT_NAME}_CMakeFormat_FILES_RE "^.*\\\\.cmake$$" "^.*CMakeLists.txt$$"
+  set(${PROJECT_PREFIX}_CMakeFormat_OPTIONS "" CACHE STRING "cmake-format options")
+  set(${PROJECT_PREFIX}_CMakeFormat_FILES_RE "^.*\\\\.cmake$$" "^.*CMakeLists.txt$$"
       CACHE STRING "List of regular expressions matching CMake files")
-  set(${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
+  set(${PROJECT_PREFIX}_CMakeFormat_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude CMake files from formatting")
-  mark_as_advanced(${PROJECT_NAME}_CMakeFormat_OPTIONS ${PROJECT_NAME}_CMakeFormat_FILES_RE
-                   ${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE)
+  mark_as_advanced(${PROJECT_PREFIX}_CMakeFormat_OPTIONS ${PROJECT_PREFIX}_CMakeFormat_FILES_RE
+                   ${PROJECT_PREFIX}_CMakeFormat_EXCLUDES_RE)
   execute_process(COMMAND git ls-files --error-unmatch .cmake-format
           WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
           RESULT_VARIABLE is_cmake_format_config_tracked
@@ -149,29 +149,29 @@ function(bbp_enable_cmake_formatting)
       "${CMAKE_BINARY_DIR}"
       "--executable=${CMakeFormat_EXECUTABLE}"
       --files-re
-      ${${PROJECT_NAME}_CMakeFormat_FILES_RE}
-      $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      ${${PROJECT_PREFIX}_CMakeFormat_FILES_RE}
+      $<$<BOOL:${PROJECT_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${PROJECT_NAME}_CMakeFormat_EXCLUDES_RE}
-      --applies-on=${${PROJECT_NAME}_FORMATTING_ON})
+      ${${PROJECT_PREFIX}_CMakeFormat_EXCLUDES_RE}
+      --applies-on=${${PROJECT_PREFIX}_FORMATTING_ON})
   add_custom_target(cmake-format
                     ${cmake_format_command_prefix}
                     --action
                     format
                     --
-                    "${${PROJECT_NAME}_CMakeFormat_OPTIONS}")
+                    "${${PROJECT_PREFIX}_CMakeFormat_OPTIONS}")
   add_custom_target(check-cmake-format
                     ${cmake_format_command_prefix}
                     --action
                     check
                     --
-                    ${${PROJECT_NAME}_CMakeFormat_OPTIONS})
-  if(${PROJECT_NAME}_TEST_FORMATTING)
+                    ${${PROJECT_PREFIX}_CMakeFormat_OPTIONS})
+  if(${PROJECT_PREFIX}_TEST_FORMATTING)
     add_test(NAME CMakeFormat
              COMMAND ${cmake_format_command_prefix}
                      --action check
                      --make-unescape-re
-                     -- ${${PROJECT_NAME}_CMakeFormat_OPTIONS})
+                     -- ${${PROJECT_PREFIX}_CMakeFormat_OPTIONS})
   endif()
 
 endfunction(bbp_enable_cmake_formatting)
@@ -179,20 +179,20 @@ endfunction(bbp_enable_cmake_formatting)
 function(bbp_enable_static_analysis)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(ClangTidy 7 EXACT REQUIRED)
-  set(${PROJECT_NAME}_ClangTidy_OPTIONS -extra-arg=-Wno-unknown-warning-option
+  set(${PROJECT_PREFIX}_ClangTidy_OPTIONS -extra-arg=-Wno-unknown-warning-option
       CACHE STRING "clang-tidy command options")
-  mark_as_advanced(${PROJECT_NAME}_ClangTidy_OPTIONS)
-  set(${PROJECT_NAME}_ClangTidy_FILES_RE
+  mark_as_advanced(${PROJECT_PREFIX}_ClangTidy_OPTIONS)
+  set(${PROJECT_PREFIX}_ClangTidy_FILES_RE
       "^.*\\\\.cc$$"
       "^.*\\\\.cpp$$"
       "^.*\\\\.cxx$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
-  set(${PROJECT_NAME}_ClangTidy_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
+  set(${PROJECT_PREFIX}_ClangTidy_EXCLUDES_RE ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")
-  set(${PROJECT_NAME}_ClangTidy_DEPENDENCIES ""
+  set(${PROJECT_PREFIX}_ClangTidy_DEPENDENCIES ""
       CACHE STRING "list of CMake targets to build before formatting C/C++ code")
-  mark_as_advanced(${PROJECT_NAME}_ClangTidy_OPTIONS ${PROJECT_NAME}_ClangTidy_FILES_RE
-                   ${PROJECT_NAME}_ClangTidy_EXCLUDES_RE)
+  mark_as_advanced(${PROJECT_PREFIX}_ClangTidy_OPTIONS ${PROJECT_PREFIX}_ClangTidy_FILES_RE
+                   ${PROJECT_PREFIX}_ClangTidy_EXCLUDES_RE)
   execute_process(COMMAND git ls-files --error-unmatch .clang-tidy
                   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                   RESULT_VARIABLE is_clang_tidy_config_tracked
@@ -218,72 +218,78 @@ function(bbp_enable_static_analysis)
       "${CMAKE_BINARY_DIR}"
       "--executable=${ClangTidy_EXECUTABLE}"
       --files-re
-      "${${PROJECT_NAME}_ClangTidy_FILES_RE}"
-      $<$<BOOL:${PROJECT_NAME}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      "${${PROJECT_PREFIX}_ClangTidy_FILES_RE}"
+      $<$<BOOL:${PROJECT_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${PROJECT_NAME}_ClangTidy_EXCLUDES_RE}
+      ${${PROJECT_PREFIX}_ClangTidy_EXCLUDES_RE}
       -p
       ${CMAKE_BINARY_DIR}/compile_commands.json
       --action
       check)
-  add_custom_target(clang-tidy ${clang_tidy_command_prefix} -- ${${PROJECT_NAME}_ClangTidy_OPTIONS})
-  if(${PROJECT_NAME}_TEST_STATIC_ANALYSIS)
+  add_custom_target(clang-tidy ${clang_tidy_command_prefix} -- ${${PROJECT_PREFIX}_ClangTidy_OPTIONS})
+  if(${PROJECT_PREFIX}_TEST_STATIC_ANALYSIS)
     add_test(NAME ClangTidy
              COMMAND ${clang_tidy_command_prefix}
                      --make-unescape-re
-                     -- ${${PROJECT_NAME}_ClangTidy_OPTIONS})
+                     -- ${${PROJECT_PREFIX}_ClangTidy_OPTIONS})
   endif()
-  if(${PROJECT_NAME}_ClangTidy_DEPENDENCIES)
-    add_dependencies(clang-tidy ${${PROJECT_NAME}_ClangTidy_DEPENDENCIES})
+  if(${PROJECT_PREFIX}_ClangTidy_DEPENDENCIES)
+    add_dependencies(clang-tidy ${${PROJECT_PREFIX}_ClangTidy_DEPENDENCIES})
   endif()
 
 endfunction(bbp_enable_static_analysis)
 
-bob_option(${PROJECT_NAME}_FORMATTING "Enable helpers to keep CMake and C++ code properly formatted"
+bob_input(${PROJECT_NAME}_CODING_CONV_PREFIX
+          "${PROJECT_NAME}"
+          STRING
+          "Override coding conventions options prefix (default: PROJECT_NAME)")
+set(PROJECT_PREFIX "${${PROJECT_NAME}_CODING_CONV_PREFIX}")
+
+bob_option(${PROJECT_PREFIX}_FORMATTING "Enable helpers to keep CMake and C++ code properly formatted"
            OFF)
-bob_input(${PROJECT_NAME}_FORMATTING_ON
+bob_input(${PROJECT_PREFIX}_FORMATTING_ON
           "all"
           STRING
           "Specify changeset where formatting applies (see documentation for detailed information)")
-bob_option(${PROJECT_NAME}_FORMATTING_CPP_CHANGES_ONLY
+bob_option(${PROJECT_PREFIX}_FORMATTING_CPP_CHANGES_ONLY
            "Only format the modified chunks, not the entire files" OFF)
-bob_option(${PROJECT_NAME}_TEST_FORMATTING "Add CTest formatting test" OFF)
-bob_option(${PROJECT_NAME}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
-bob_option(${PROJECT_NAME}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)
-bob_option(${PROJECT_NAME}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted" OFF)
+bob_option(${PROJECT_PREFIX}_TEST_FORMATTING "Add CTest formatting test" OFF)
+bob_option(${PROJECT_PREFIX}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
+bob_option(${PROJECT_PREFIX}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)
+bob_option(${PROJECT_PREFIX}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted" OFF)
 
-bob_option(${PROJECT_NAME}_PRECOMMIT "Enable automatic checks before git commits" OFF)
-bob_option(${PROJECT_NAME}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
+bob_option(${PROJECT_PREFIX}_PRECOMMIT "Enable automatic checks before git commits" OFF)
+bob_option(${PROJECT_PREFIX}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
 
-bob_option(${PROJECT_NAME}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
-bob_option(${PROJECT_NAME}_TEST_STATIC_ANALYSIS "Add CTest static analysis test" OFF)
+bob_option(${PROJECT_PREFIX}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
+bob_option(${PROJECT_PREFIX}_TEST_STATIC_ANALYSIS "Add CTest static analysis test" OFF)
 
-if(${PROJECT_NAME}_CLANG_FORMAT)
+if(${PROJECT_PREFIX}_CLANG_FORMAT)
   bbp_enable_clang_formatting()
-endif(${PROJECT_NAME}_CLANG_FORMAT)
+endif(${PROJECT_PREFIX}_CLANG_FORMAT)
 
-if(${PROJECT_NAME}_CMAKE_FORMAT)
+if(${PROJECT_PREFIX}_CMAKE_FORMAT)
   bbp_enable_cmake_formatting()
-endif(${PROJECT_NAME}_CMAKE_FORMAT)
+endif(${PROJECT_PREFIX}_CMAKE_FORMAT)
 
-if(${PROJECT_NAME}_FORMATTING)
+if(${PROJECT_PREFIX}_FORMATTING)
   bbp_enable_clang_formatting()
   bbp_enable_cmake_formatting()
-endif(${PROJECT_NAME}_FORMATTING)
+endif(${PROJECT_PREFIX}_FORMATTING)
 
-if(${PROJECT_NAME}_PRECOMMIT)
+if(${PROJECT_PREFIX}_PRECOMMIT)
   bbp_enable_precommit()
-else(${PROJECT_NAME}_PRECOMMIT)
+else(${PROJECT_PREFIX}_PRECOMMIT)
   bbp_disable_precommit()
-endif(${PROJECT_NAME}_PRECOMMIT)
+endif(${PROJECT_PREFIX}_PRECOMMIT)
 
-if(${PROJECT_NAME}_STATIC_ANALYSIS)
+if(${PROJECT_PREFIX}_STATIC_ANALYSIS)
   cmake_minimum_required(VERSION 3.6)
   bbp_enable_static_analysis()
   set(CMAKE_CXX_CLANG_TIDY
       "${ClangTidy_EXECUTABLE}"
       -p
       "${CMAKE_BINARY_DIR}/compile_commands.json"
-      ${${PROJECT_NAME}_ClangTidy_OPTIONS}
+      ${${PROJECT_PREFIX}_ClangTidy_OPTIONS}
       PARENT_SCOPE)
-endif(${PROJECT_NAME}_STATIC_ANALYSIS)
+endif(${PROJECT_PREFIX}_STATIC_ANALYSIS)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -5,10 +5,10 @@ set(CMAKE_MODULE_PATH
 set(CMAKE_EXPORT_COMPILE_COMMANDS
     ON
     PARENT_SCOPE)
-if(NOT BBPCC_VAR_PREFIX)
-  set(BBPCC_VAR_PREFIX "${PROJECT_NAME}")
-  set(BBPCC_VAR_PREFIX "${PROJECT_NAME}" PARENT_SCOPE)
-endif(NOT BBPCC_VAR_PREFIX)
+if(NOT CODING_CONV_PREFIX)
+  set(CODING_CONV_PREFIX "${PROJECT_NAME}")
+  set(CODING_CONV_PREFIX "${PROJECT_NAME}" PARENT_SCOPE)
+endif(NOT CODING_CONV_PREFIX)
 include(cmake/bob.cmake)
 
 function(bbp_enable_precommit)
@@ -18,9 +18,9 @@ function(bbp_enable_precommit)
   execute_process(
     COMMAND
       ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
-      --force ${${BBPCC_VAR_PREFIX}_PRECOMMIT_REGEN} --clang-format
-      ${${BBPCC_VAR_PREFIX}_FORMATTING} --cmake-format ${${BBPCC_VAR_PREFIX}_FORMATTING}
-      --clang-tidy ${${BBPCC_VAR_PREFIX}_STATIC_ANALYSIS} ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+      --force ${${CODING_CONV_PREFIX}_PRECOMMIT_REGEN} --clang-format
+      ${${CODING_CONV_PREFIX}_FORMATTING} --cmake-format ${${CODING_CONV_PREFIX}_FORMATTING}
+      --clang-tidy ${${CODING_CONV_PREFIX}_STATIC_ANALYSIS} ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   add_custom_target(git-pre-commits ${PreCommit_EXECUTABLE} run --all-files)
 endfunction(bbp_enable_precommit)
 
@@ -43,7 +43,7 @@ function(bbp_enable_clang_formatting)
     return()
   endif()
   if(ClangFormat_VERSION_MAJOR GREATER 6 AND ClangFormat_VERSION_MAJOR LESS 10)
-    set(${BBPCC_VAR_PREFIX}_ClangFormat_CONFIG_FILE .clang-format-${ClangFormat_VERSION_MAJOR})
+    set(${CODING_CONV_PREFIX}_ClangFormat_CONFIG_FILE .clang-format-${ClangFormat_VERSION_MAJOR})
   else()
     message(
       SEND_ERROR
@@ -51,20 +51,20 @@ function(bbp_enable_clang_formatting)
     )
   endif()
 
-  set(${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS
+  set(${CODING_CONV_PREFIX}_ClangFormat_OPTIONS
       ""
       CACHE STRING "clang-format command options")
-  set(${BBPCC_VAR_PREFIX}_ClangFormat_FILES_RE
+  set(${CODING_CONV_PREFIX}_ClangFormat_FILES_RE
       "^.*\\\\.cc?$$" "^.*\\\\.hh?$$" "^.*\\\\.[it]cc$$" "^.*\\\\.[chit]pp$$" "^.*\\\\.[chit]xx$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
-  set(${BBPCC_VAR_PREFIX}_ClangFormat_EXCLUDES_RE
+  set(${CODING_CONV_PREFIX}_ClangFormat_EXCLUDES_RE
       ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")
-  set(${BBPCC_VAR_PREFIX}_ClangFormat_DEPENDENCIES
+  set(${CODING_CONV_PREFIX}_ClangFormat_DEPENDENCIES
       ""
       CACHE STRING "list of CMake targets to build before formatting C/C++ code")
-  mark_as_advanced(${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS ${BBPCC_VAR_PREFIX}_ClangFormat_FILES_RE
-                   ${BBPCC_VAR_PREFIX}_ClangFormat_EXCLUDES_RE)
+  mark_as_advanced(${CODING_CONV_PREFIX}_ClangFormat_OPTIONS ${CODING_CONV_PREFIX}_ClangFormat_FILES_RE
+                   ${CODING_CONV_PREFIX}_ClangFormat_EXCLUDES_RE)
   execute_process(
     COMMAND git ls-files --error-unmatch .clang-format
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
@@ -74,10 +74,10 @@ function(bbp_enable_clang_formatting)
     if(EXISTS ${PROJECT_SOURCE_DIR}/.clang-format.changes)
       execute_process(
         COMMAND ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpplib.py" merge-yaml
-                "${CMAKE_CURRENT_SOURCE_DIR}/${${BBPCC_VAR_PREFIX}_ClangFormat_CONFIG_FILE}"
+                "${CMAKE_CURRENT_SOURCE_DIR}/${${CODING_CONV_PREFIX}_ClangFormat_CONFIG_FILE}"
                 "${PROJECT_SOURCE_DIR}/.clang-format.changes" "${PROJECT_SOURCE_DIR}/.clang-format")
     else()
-      configure_file(${${BBPCC_VAR_PREFIX}_ClangFormat_CONFIG_FILE}
+      configure_file(${${CODING_CONV_PREFIX}_ClangFormat_CONFIG_FILE}
                      ${PROJECT_SOURCE_DIR}/.clang-format COPYONLY)
     endif()
   endif()
@@ -92,44 +92,44 @@ function(bbp_enable_clang_formatting)
       "${CMAKE_BINARY_DIR}"
       "--executable=${ClangFormat_EXECUTABLE}"
       "--clang-format-diff-executable=${ClangFormatDiff_EXECUTABLE}"
-      "--changes-only=${${BBPCC_VAR_PREFIX}_FORMATTING_CPP_CHANGES_ONLY}"
+      "--changes-only=${${CODING_CONV_PREFIX}_FORMATTING_CPP_CHANGES_ONLY}"
       --files-re
-      ${${BBPCC_VAR_PREFIX}_ClangFormat_FILES_RE}
-      $<$<BOOL:${BBPCC_VAR_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      ${${CODING_CONV_PREFIX}_ClangFormat_FILES_RE}
+      $<$<BOOL:${CODING_CONV_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${BBPCC_VAR_PREFIX}_ClangFormat_EXCLUDES_RE}
+      ${${CODING_CONV_PREFIX}_ClangFormat_EXCLUDES_RE}
       -p
       ${CMAKE_BINARY_DIR}/compile_commands.json
-      --applies-on=${${BBPCC_VAR_PREFIX}_FORMATTING_ON})
+      --applies-on=${${CODING_CONV_PREFIX}_FORMATTING_ON})
   add_custom_target(clang-format ${clang_format_command_prefix} --action format --
-                    "${${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS}")
+                    "${${CODING_CONV_PREFIX}_ClangFormat_OPTIONS}")
   add_custom_target(check-clang-format ${clang_format_command_prefix} --action check --
-                    "${${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS}")
-  if(${BBPCC_VAR_PREFIX}_TEST_FORMATTING)
+                    "${${CODING_CONV_PREFIX}_ClangFormat_OPTIONS}")
+  if(${CODING_CONV_PREFIX}_TEST_FORMATTING)
     add_test(NAME ClangFormat
              COMMAND ${clang_format_command_prefix} --action check --make-unescape-re --
-                     "${${BBPCC_VAR_PREFIX}_ClangFormat_OPTIONS}")
+                     "${${CODING_CONV_PREFIX}_ClangFormat_OPTIONS}")
   endif()
-  if(${BBPCC_VAR_PREFIX}_ClangFormat_DEPENDENCIES)
-    add_dependencies(clang-format ${${BBPCC_VAR_PREFIX}_ClangFormat_DEPENDENCIES})
-    add_dependencies(check-clang-format ${${BBPCC_VAR_PREFIX}_ClangFormat_DEPENDENCIES})
+  if(${CODING_CONV_PREFIX}_ClangFormat_DEPENDENCIES)
+    add_dependencies(clang-format ${${CODING_CONV_PREFIX}_ClangFormat_DEPENDENCIES})
+    add_dependencies(check-clang-format ${${CODING_CONV_PREFIX}_ClangFormat_DEPENDENCIES})
   endif()
 endfunction(bbp_enable_clang_formatting)
 
 function(bbp_enable_cmake_formatting)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(CMakeFormat 0.6.0 EXACT REQUIRED)
-  set(${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS
+  set(${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS
       ""
       CACHE STRING "cmake-format options")
-  set(${BBPCC_VAR_PREFIX}_CMakeFormat_FILES_RE
+  set(${CODING_CONV_PREFIX}_CMakeFormat_FILES_RE
       "^.*\\\\.cmake$$" "^.*CMakeLists.txt$$"
       CACHE STRING "List of regular expressions matching CMake files")
-  set(${BBPCC_VAR_PREFIX}_CMakeFormat_EXCLUDES_RE
+  set(${CODING_CONV_PREFIX}_CMakeFormat_EXCLUDES_RE
       ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude CMake files from formatting")
-  mark_as_advanced(${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS ${BBPCC_VAR_PREFIX}_CMakeFormat_FILES_RE
-                   ${BBPCC_VAR_PREFIX}_CMakeFormat_EXCLUDES_RE)
+  mark_as_advanced(${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS ${CODING_CONV_PREFIX}_CMakeFormat_FILES_RE
+                   ${CODING_CONV_PREFIX}_CMakeFormat_EXCLUDES_RE)
   execute_process(
     COMMAND git ls-files --error-unmatch .cmake-format
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
@@ -156,19 +156,19 @@ function(bbp_enable_cmake_formatting)
       "${CMAKE_BINARY_DIR}"
       "--executable=${CMakeFormat_EXECUTABLE}"
       --files-re
-      ${${BBPCC_VAR_PREFIX}_CMakeFormat_FILES_RE}
-      $<$<BOOL:${BBPCC_VAR_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      ${${CODING_CONV_PREFIX}_CMakeFormat_FILES_RE}
+      $<$<BOOL:${CODING_CONV_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${BBPCC_VAR_PREFIX}_CMakeFormat_EXCLUDES_RE}
-      --applies-on=${${BBPCC_VAR_PREFIX}_FORMATTING_ON})
+      ${${CODING_CONV_PREFIX}_CMakeFormat_EXCLUDES_RE}
+      --applies-on=${${CODING_CONV_PREFIX}_FORMATTING_ON})
   add_custom_target(cmake-format ${cmake_format_command_prefix} --action format --
-                    "${${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS}")
+                    "${${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS}")
   add_custom_target(check-cmake-format ${cmake_format_command_prefix} --action check --
-                    ${${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS})
-  if(${BBPCC_VAR_PREFIX}_TEST_FORMATTING)
+                    ${${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS})
+  if(${CODING_CONV_PREFIX}_TEST_FORMATTING)
     add_test(NAME CMakeFormat
              COMMAND ${cmake_format_command_prefix} --action check --make-unescape-re --
-                     ${${BBPCC_VAR_PREFIX}_CMakeFormat_OPTIONS})
+                     ${${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS})
   endif()
 
 endfunction(bbp_enable_cmake_formatting)
@@ -176,21 +176,21 @@ endfunction(bbp_enable_cmake_formatting)
 function(bbp_enable_static_analysis)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(ClangTidy 7 EXACT REQUIRED)
-  set(${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS
+  set(${CODING_CONV_PREFIX}_ClangTidy_OPTIONS
       -extra-arg=-Wno-unknown-warning-option
       CACHE STRING "clang-tidy command options")
-  mark_as_advanced(${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS)
-  set(${BBPCC_VAR_PREFIX}_ClangTidy_FILES_RE
+  mark_as_advanced(${CODING_CONV_PREFIX}_ClangTidy_OPTIONS)
+  set(${CODING_CONV_PREFIX}_ClangTidy_FILES_RE
       "^.*\\\\.cc$$" "^.*\\\\.cpp$$" "^.*\\\\.cxx$$"
       CACHE STRING "List of regular expressions matching C/C++ filenames")
-  set(${BBPCC_VAR_PREFIX}_ClangTidy_EXCLUDES_RE
+  set(${CODING_CONV_PREFIX}_ClangTidy_EXCLUDES_RE
       ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude C/C++ files from formatting")
-  set(${BBPCC_VAR_PREFIX}_ClangTidy_DEPENDENCIES
+  set(${CODING_CONV_PREFIX}_ClangTidy_DEPENDENCIES
       ""
       CACHE STRING "list of CMake targets to build before formatting C/C++ code")
-  mark_as_advanced(${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS ${BBPCC_VAR_PREFIX}_ClangTidy_FILES_RE
-                   ${BBPCC_VAR_PREFIX}_ClangTidy_EXCLUDES_RE)
+  mark_as_advanced(${CODING_CONV_PREFIX}_ClangTidy_OPTIONS ${CODING_CONV_PREFIX}_ClangTidy_FILES_RE
+                   ${CODING_CONV_PREFIX}_ClangTidy_EXCLUDES_RE)
   execute_process(
     COMMAND git ls-files --error-unmatch .clang-tidy
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
@@ -217,68 +217,68 @@ function(bbp_enable_static_analysis)
       "${CMAKE_BINARY_DIR}"
       "--executable=${ClangTidy_EXECUTABLE}"
       --files-re
-      "${${BBPCC_VAR_PREFIX}_ClangTidy_FILES_RE}"
-      $<$<BOOL:${BBPCC_VAR_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
+      "${${CODING_CONV_PREFIX}_ClangTidy_FILES_RE}"
+      $<$<BOOL:${CODING_CONV_PREFIX}_FORMATTING_NO_SUBMODULES>:--git-modules>
       --excludes-re
-      ${${BBPCC_VAR_PREFIX}_ClangTidy_EXCLUDES_RE}
+      ${${CODING_CONV_PREFIX}_ClangTidy_EXCLUDES_RE}
       -p
       ${CMAKE_BINARY_DIR}/compile_commands.json
       --action
       check)
   add_custom_target(clang-tidy ${clang_tidy_command_prefix} --
-                    ${${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS})
-  if(${BBPCC_VAR_PREFIX}_TEST_STATIC_ANALYSIS)
+                    ${${CODING_CONV_PREFIX}_ClangTidy_OPTIONS})
+  if(${CODING_CONV_PREFIX}_TEST_STATIC_ANALYSIS)
     add_test(NAME ClangTidy COMMAND ${clang_tidy_command_prefix} --make-unescape-re --
-                                    ${${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS})
+                                    ${${CODING_CONV_PREFIX}_ClangTidy_OPTIONS})
   endif()
-  if(${BBPCC_VAR_PREFIX}_ClangTidy_DEPENDENCIES)
-    add_dependencies(clang-tidy ${${BBPCC_VAR_PREFIX}_ClangTidy_DEPENDENCIES})
+  if(${CODING_CONV_PREFIX}_ClangTidy_DEPENDENCIES)
+    add_dependencies(clang-tidy ${${CODING_CONV_PREFIX}_ClangTidy_DEPENDENCIES})
   endif()
 
 endfunction(bbp_enable_static_analysis)
 
-bob_option(${BBPCC_VAR_PREFIX}_FORMATTING
+bob_option(${CODING_CONV_PREFIX}_FORMATTING
            "Enable helpers to keep CMake and C++ code properly formatted" OFF)
-bob_input(${BBPCC_VAR_PREFIX}_FORMATTING_ON "all" STRING
+bob_input(${CODING_CONV_PREFIX}_FORMATTING_ON "all" STRING
           "Specify changeset where formatting applies (see documentation for detailed information)")
-bob_option(${BBPCC_VAR_PREFIX}_FORMATTING_CPP_CHANGES_ONLY
+bob_option(${CODING_CONV_PREFIX}_FORMATTING_CPP_CHANGES_ONLY
            "Only format the modified chunks, not the entire files" OFF)
-bob_option(${BBPCC_VAR_PREFIX}_TEST_FORMATTING "Add CTest formatting test" OFF)
-bob_option(${BBPCC_VAR_PREFIX}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
-bob_option(${BBPCC_VAR_PREFIX}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)
-bob_option(${BBPCC_VAR_PREFIX}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted"
+bob_option(${CODING_CONV_PREFIX}_TEST_FORMATTING "Add CTest formatting test" OFF)
+bob_option(${CODING_CONV_PREFIX}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
+bob_option(${CODING_CONV_PREFIX}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)
+bob_option(${CODING_CONV_PREFIX}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted"
            OFF)
 
-bob_option(${BBPCC_VAR_PREFIX}_PRECOMMIT "Enable automatic checks before git commits" OFF)
-bob_option(${BBPCC_VAR_PREFIX}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
+bob_option(${CODING_CONV_PREFIX}_PRECOMMIT "Enable automatic checks before git commits" OFF)
+bob_option(${CODING_CONV_PREFIX}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
 
-bob_option(${BBPCC_VAR_PREFIX}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
-bob_option(${BBPCC_VAR_PREFIX}_TEST_STATIC_ANALYSIS "Add CTest static analysis test" OFF)
+bob_option(${CODING_CONV_PREFIX}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
+bob_option(${CODING_CONV_PREFIX}_TEST_STATIC_ANALYSIS "Add CTest static analysis test" OFF)
 
-if(${BBPCC_VAR_PREFIX}_CLANG_FORMAT)
+if(${CODING_CONV_PREFIX}_CLANG_FORMAT)
   bbp_enable_clang_formatting()
-endif(${BBPCC_VAR_PREFIX}_CLANG_FORMAT)
+endif(${CODING_CONV_PREFIX}_CLANG_FORMAT)
 
-if(${BBPCC_VAR_PREFIX}_CMAKE_FORMAT)
+if(${CODING_CONV_PREFIX}_CMAKE_FORMAT)
   bbp_enable_cmake_formatting()
-endif(${BBPCC_VAR_PREFIX}_CMAKE_FORMAT)
+endif(${CODING_CONV_PREFIX}_CMAKE_FORMAT)
 
-if(${BBPCC_VAR_PREFIX}_FORMATTING)
+if(${CODING_CONV_PREFIX}_FORMATTING)
   bbp_enable_clang_formatting()
   bbp_enable_cmake_formatting()
-endif(${BBPCC_VAR_PREFIX}_FORMATTING)
+endif(${CODING_CONV_PREFIX}_FORMATTING)
 
-if(${BBPCC_VAR_PREFIX}_PRECOMMIT)
+if(${CODING_CONV_PREFIX}_PRECOMMIT)
   bbp_enable_precommit()
-else(${BBPCC_VAR_PREFIX}_PRECOMMIT)
+else(${CODING_CONV_PREFIX}_PRECOMMIT)
   bbp_disable_precommit()
-endif(${BBPCC_VAR_PREFIX}_PRECOMMIT)
+endif(${CODING_CONV_PREFIX}_PRECOMMIT)
 
-if(${BBPCC_VAR_PREFIX}_STATIC_ANALYSIS)
+if(${CODING_CONV_PREFIX}_STATIC_ANALYSIS)
   cmake_minimum_required(VERSION 3.6)
   bbp_enable_static_analysis()
   set(CMAKE_CXX_CLANG_TIDY
       "${ClangTidy_EXECUTABLE}" -p "${CMAKE_BINARY_DIR}/compile_commands.json"
-      ${${BBPCC_VAR_PREFIX}_ClangTidy_OPTIONS}
+      ${${CODING_CONV_PREFIX}_ClangTidy_OPTIONS}
       PARENT_SCOPE)
-endif(${BBPCC_VAR_PREFIX}_STATIC_ANALYSIS)
+endif(${CODING_CONV_PREFIX}_STATIC_ANALYSIS)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -324,8 +324,15 @@ _bob_ sets the compilation flags according to a set of CMake variables:
 * `${PROJECT_NAME}_NORMAL_CXX_FLAGS:BOOL`: Allow `CMAKE_CXX_FLAGS` to follow _normal_ CMake behavior
   and bypass all variables above.
 
-Alternatively you can set `${PROJECT_NAME}_CODING_CONV_PREFIX:BOOL` to a user defined string to
-prefix above bob compilation flags.
+Alternatively you can set in your `CMakeLists.txt` `${PROJECT_NAME}_CODING_CONV_PREFIX:STRING` to a user
+defined string to prefix above bob compilation flags before including hpc-coding-conventions. For example:
+
+```cmake
+set(project_name_CODING_CONV_PREFIX
+        "my_cmake_prefix"
+        CACHE STRING "Override coding conventions options prefix (default: PROJECT_NAME)")
+add_subdirectory(cmake/hpc-coding-conventions/cpp)
+```
 
 Default `CMAKE_CXX_FLAGS` variable value is taken into account.
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -79,12 +79,12 @@ After cloning or updating this git submodule, run CMake to take benefits of the 
 This will setup or update git [pre-commit](https://pre-commit.com) hooks of this repository.
 
 CMake variables defined by this project are prefixed by `${PROJECT_NAME}` by default.
-The CMake variable `BBPCC_VAR_PREFIX` allows to specify another prefix. It must be defined
+The CMake variable `CODING_CONV_PREFIX` allows to specify another prefix. It must be defined
 before including this CMake project, for instance:
 ```cmake
 project(mylib CXX)
 # [...]
-set(BBPCC_VAR_PREFIX Foo)
+set(CODING_CONV_PREFIX Foo)
 add_subdirectory(hpc-coding-conventions/cpp)
 ```
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -324,6 +324,9 @@ _bob_ sets the compilation flags according to a set of CMake variables:
 * `${PROJECT_NAME}_NORMAL_CXX_FLAGS:BOOL`: Allow `CMAKE_CXX_FLAGS` to follow _normal_ CMake behavior
   and bypass all variables above.
 
+Alternatively you can set `${PROJECT_NAME}_CODING_CONV_PREFIX:BOOL` to a user defined string to
+prefix above bob compilation flags.
+
 Default `CMAKE_CXX_FLAGS` variable value is taken into account.
 
 ##### Integration

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -78,6 +78,16 @@ add_subdirectory(hpc-coding-conventions/cpp)
 After cloning or updating this git submodule, run CMake to take benefits of the latest changes.
 This will setup or update git [pre-commit](https://pre-commit.com) hooks of this repository.
 
+CMake variables defined by this project are prefixed by `${PROJECT_NAME}` by default.
+The CMake variable `BBPCC_VAR_PREFIX` allows to specify another prefix. It must be defined
+before including this CMake project, for instance:
+```cmake
+project(mylib CXX)
+# [...]
+set(BBPCC_VAR_PREFIX Foo)
+add_subdirectory(hpc-coding-conventions/cpp)
+```
+
 ### Usage
 
 #### Code Formatting
@@ -323,16 +333,6 @@ _bob_ sets the compilation flags according to a set of CMake variables:
   compilation flags. `CMAKE_BUILD_TYPE` is ignored.
 * `${PROJECT_NAME}_NORMAL_CXX_FLAGS:BOOL`: Allow `CMAKE_CXX_FLAGS` to follow _normal_ CMake behavior
   and bypass all variables above.
-
-Alternatively you can set in your `CMakeLists.txt` `${PROJECT_NAME}_CODING_CONV_PREFIX:STRING` to a user
-defined string to prefix above bob compilation flags before including hpc-coding-conventions. For example:
-
-```cmake
-set(project_name_CODING_CONV_PREFIX
-        "my_cmake_prefix"
-        CACHE STRING "Override coding conventions options prefix (default: PROJECT_NAME)")
-add_subdirectory(cmake/hpc-coding-conventions/cpp)
-```
 
 Default `CMAKE_CXX_FLAGS` variable value is taken into account.
 

--- a/cpp/cmake/bob.cmake
+++ b/cpp/cmake/bob.cmake
@@ -17,13 +17,13 @@ endfunction(bob_always_full_rpath)
 
 function(bob_cmake_arg2 var type default)
   if(NOT ${var} STREQUAL "${default}")
-    if(${PROJECT_NAME}_CMAKE_ARGS)
+    if(${BBPCC_VAR_PREFIX}_CMAKE_ARGS)
       set(sep " ")
     else()
       set(sep "")
     endif()
-    set(${PROJECT_NAME}_CMAKE_ARGS
-        "${${PROJECT_NAME}_CMAKE_ARGS}${sep}-D${var}:${type}=\"${${var}}\""
+    set(${BBPCC_VAR_PREFIX}_CMAKE_ARGS
+        "${${BBPCC_VAR_PREFIX}_CMAKE_ARGS}${sep}-D${var}:${type}=\"${${var}}\""
         CACHE STRING "CMake arguments that would replicate this configuration"
         FORCE)
   endif()
@@ -45,12 +45,12 @@ function(bob_input var default type desc)
 endfunction()
 
 macro(bob_begin_package)
-  set(${PROJECT_NAME}_CMAKE_ARGS ""
+  set(${BBPCC_VAR_PREFIX}_CMAKE_ARGS ""
       CACHE STRING "CMake arguments that would replicate this configuration"
       FORCE)
   message(STATUS "CMAKE_VERSION: ${CMAKE_VERSION}")
-  if(${PROJECT_NAME}_VERSION)
-    message(STATUS "${PROJECT_NAME}_VERSION: ${${PROJECT_NAME}_VERSION}")
+  if(${BBPCC_VAR_PREFIX}_VERSION)
+    message(STATUS "${BBPCC_VAR_PREFIX}_VERSION: ${${BBPCC_VAR_PREFIX}_VERSION}")
   endif()
   option(USE_XSDK_DEFAULTS "enable the XDSK v0.3.0 default configuration" OFF)
   bob_cmake_arg(USE_XSDK_DEFAULTS BOOL OFF)
@@ -76,7 +76,7 @@ macro(bob_begin_package)
   bob_cmake_arg(BUILD_TESTING BOOL OFF)
   bob_cmake_arg(BUILD_SHARED_LIBS BOOL ON)
   bob_cmake_arg(CMAKE_INSTALL_PREFIX PATH "")
-  option(${PROJECT_NAME}_NORMAL_CXX_FLAGS
+  option(${BBPCC_VAR_PREFIX}_NORMAL_CXX_FLAGS
          "Allow CMAKE_CXX_FLAGS to follow \"normal\" CMake behavior" ${USE_XSDK_DEFAULTS})
 endmacro(bob_begin_package)
 
@@ -90,7 +90,7 @@ function(bob_get_commit)
   if(NO_SHA1)
     message(WARNING "bob_get_commit: no Git hash!\n" ${SHA1_ERROR})
   else()
-    set(${PROJECT_NAME}_COMMIT "${SHA1}" PARENT_SCOPE)
+    set(${BBPCC_VAR_PREFIX}_COMMIT "${SHA1}" PARENT_SCOPE)
   endif()
 endfunction(bob_get_commit)
 
@@ -102,8 +102,8 @@ function(bob_get_semver)
                   ERROR_VARIABLE TAG_ERROR
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
   if(NOT_TAG)
-    if(${PROJECT_NAME}_VERSION)
-      set(SEMVER ${${PROJECT_NAME}_VERSION})
+    if(${BBPCC_VAR_PREFIX}_VERSION)
+      set(SEMVER ${${BBPCC_VAR_PREFIX}_VERSION})
       execute_process(COMMAND git log -1 --format=%h
                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                       RESULT_VARIABLE NO_SHA1
@@ -116,7 +116,7 @@ function(bob_get_semver)
         set(SEMVER "${SEMVER}-sha.${SHORT_SHA1}")
       endif()
     else()
-      message(FATAL_ERROR "bob_get_semver needs either ${PROJECT_NAME}_VERSION or a Git tag\n"
+      message(FATAL_ERROR "bob_get_semver needs either ${BBPCC_VAR_PREFIX}_VERSION or a Git tag\n"
                           ${TAG_ERROR})
     endif()
   else()
@@ -125,25 +125,25 @@ function(bob_get_semver)
                        1
                        -1
                        SEMVER)
-      if(${PROJECT_NAME}_VERSION AND (NOT (SEMVER VERSION_EQUAL ${PROJECT_NAME}_VERSION)))
+      if(${BBPCC_VAR_PREFIX}_VERSION AND (NOT (SEMVER VERSION_EQUAL ${BBPCC_VAR_PREFIX}_VERSION)))
         message(
           FATAL_ERROR
-            "bob_get_semver: tag is ${TAG_NAME} but ${PROJECT_NAME}_VERSION=${${PROJECT_NAME}_VERSION} !"
+            "bob_get_semver: tag is ${TAG_NAME} but ${BBPCC_VAR_PREFIX}_VERSION=${${BBPCC_VAR_PREFIX}_VERSION} !"
           )
       endif()
     else()
-      if(${PROJECT_NAME}_VERSION)
-        set(SEMVER "${${PROJECT_NAME}_VERSION}-tag.${TAG_NAME}")
+      if(${BBPCC_VAR_PREFIX}_VERSION)
+        set(SEMVER "${${BBPCC_VAR_PREFIX}_VERSION}-tag.${TAG_NAME}")
       else()
         message(
           FATAL_ERROR
-            "bob_get_semver needs either ${PROJECT_NAME}_VERSION or a Git tag of the form v1.2.3")
+            "bob_get_semver needs either ${BBPCC_VAR_PREFIX}_VERSION or a Git tag of the form v1.2.3")
       endif()
     endif()
   endif()
-  if(${PROJECT_NAME}_KEY_BOOLS)
+  if(${BBPCC_VAR_PREFIX}_KEY_BOOLS)
     set(SEMVER "${SEMVER}+")
-    foreach(KEY_BOOL IN LISTS ${PROJECT_NAME}_KEY_BOOLS)
+    foreach(KEY_BOOL IN LISTS ${BBPCC_VAR_PREFIX}_KEY_BOOLS)
       if(${KEY_BOOL})
         set(SEMVER "${SEMVER}1")
       else()
@@ -151,8 +151,8 @@ function(bob_get_semver)
       endif()
     endforeach()
   endif()
-  set(${PROJECT_NAME}_SEMVER "${SEMVER}" PARENT_SCOPE)
-  message(STATUS "${PROJECT_NAME}_SEMVER = ${SEMVER}")
+  set(${BBPCC_VAR_PREFIX}_SEMVER "${SEMVER}" PARENT_SCOPE)
+  message(STATUS "${BBPCC_VAR_PREFIX}_SEMVER = ${SEMVER}")
 endfunction(bob_get_semver)
 
 function(bob_cxx_pedantic_flags)
@@ -225,7 +225,7 @@ function(bob_cxx_pedantic_flags)
 endfunction(bob_cxx_pedantic_flags)
 
 function(bob_begin_cxx_flags)
-  if(${PROJECT_NAME}_NORMAL_CXX_FLAGS)
+  if(${BBPCC_VAR_PREFIX}_NORMAL_CXX_FLAGS)
     set(BOB_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
     bob_cmake_arg2(CMAKE_CXX_FLAGS STRING "")
   else()
@@ -233,34 +233,34 @@ function(bob_begin_cxx_flags)
     if(CMAKE_BUILD_TYPE)
       message(FATAL_ERROR "can't set CMAKE_BUILD_TYPE and use bob_*_cxx_flags")
     endif()
-    option(${PROJECT_NAME}_CXX_OPTIMIZE "Compile C++ with optimization" ON)
-    option(${PROJECT_NAME}_CXX_SYMBOLS "Compile C++ with debug symbols" ON)
-    option(${PROJECT_NAME}_CXX_WARNINGS "Compile C++ with warnings" ON)
-    bob_cmake_arg(${PROJECT_NAME}_CXX_OPTIMIZE BOOL ON)
-    bob_cmake_arg(${PROJECT_NAME}_CXX_SYMBOLS BOOL ON)
-    set(${PROJECT_NAME}_ARCH "" CACHE STRING "Argument to -march or -arch")
-    bob_cmake_arg(${PROJECT_NAME}_ARCH STRING "native")
+    option(${BBPCC_VAR_PREFIX}_CXX_OPTIMIZE "Compile C++ with optimization" ON)
+    option(${BBPCC_VAR_PREFIX}_CXX_SYMBOLS "Compile C++ with debug symbols" ON)
+    option(${BBPCC_VAR_PREFIX}_CXX_WARNINGS "Compile C++ with warnings" ON)
+    bob_cmake_arg(${BBPCC_VAR_PREFIX}_CXX_OPTIMIZE BOOL ON)
+    bob_cmake_arg(${BBPCC_VAR_PREFIX}_CXX_SYMBOLS BOOL ON)
+    set(${BBPCC_VAR_PREFIX}_ARCH "" CACHE STRING "Argument to -march or -arch")
+    bob_cmake_arg(${BBPCC_VAR_PREFIX}_ARCH STRING "native")
     # CDash's simple output parser interprets the variable name WARNINGS as a warning...
-    message(STATUS "${PROJECT_NAME}_CXX_W**NINGS: ${${PROJECT_NAME}_CXX_WARNINGS}")
-    bob_cmake_arg2(${PROJECT_NAME}_CXX_WARNINGS BOOL ON)
+    message(STATUS "${BBPCC_VAR_PREFIX}_CXX_W**NINGS: ${${BBPCC_VAR_PREFIX}_CXX_WARNINGS}")
+    bob_cmake_arg2(${BBPCC_VAR_PREFIX}_CXX_WARNINGS BOOL ON)
     set(FLAGS "")
-    if(${PROJECT_NAME}_CXX_OPTIMIZE)
+    if(${BBPCC_VAR_PREFIX}_CXX_OPTIMIZE)
       set(FLAGS "${FLAGS} -O3 -DNDEBUG")
-      if(${PROJECT_NAME}_ARCH)
-        if(${PROJECT_NAME}_USE_CUDA)
-          set(FLAGS "${FLAGS} -arch=${${PROJECT_NAME}_ARCH}")
+      if(${BBPCC_VAR_PREFIX}_ARCH)
+        if(${BBPCC_VAR_PREFIX}_USE_CUDA)
+          set(FLAGS "${FLAGS} -arch=${${BBPCC_VAR_PREFIX}_ARCH}")
         else()
-          set(FLAGS "${FLAGS} -march=${${PROJECT_NAME}_ARCH}")
+          set(FLAGS "${FLAGS} -march=${${BBPCC_VAR_PREFIX}_ARCH}")
         endif()
       endif()
     else()
       set(FLAGS "${FLAGS} -O0")
     endif()
-    if(${PROJECT_NAME}_CXX_SYMBOLS)
+    if(${BBPCC_VAR_PREFIX}_CXX_SYMBOLS)
       set(FLAGS "${FLAGS} -g")
     endif()
     # -----------
-    if(${PROJECT_NAME}_CXX_WARNINGS)
+    if(${BBPCC_VAR_PREFIX}_CXX_WARNINGS)
       bob_cxx_pedantic_flags(FLAGS)
     endif()
     set(BOB_CMAKE_CXX_FLAGS "${FLAGS}" PARENT_SCOPE)
@@ -269,7 +269,7 @@ endfunction(bob_begin_cxx_flags)
 
 macro(bob_cxx_standard_flags standard)
   if(NOT standard VERSION_EQUAL 98 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    if(${PROJECT_NAME}_CXX_WARNINGS)
+    if(${BBPCC_VAR_PREFIX}_CXX_WARNINGS)
       set(BOB_CMAKE_CXX_FLAGS "${BOB_CMAKE_CXX_FLAGS} -Wno-c++98-compat-pedantic -Wno-c++98-compat"
           PARENT_SCOPE)
     endif()
@@ -296,18 +296,18 @@ function(bob_cxx20_flags)
 endfunction(bob_cxx20_flags)
 
 function(bob_end_cxx_flags)
-  if(${PROJECT_NAME}_NORMAL_CXX_FLAGS)
+  if(${BBPCC_VAR_PREFIX}_NORMAL_CXX_FLAGS)
     message(STATUS "CMAKE_CXX_FLAGS: ${BOB_CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS "${BOB_CMAKE_CXX_FLAGS}" PARENT_SCOPE)
   else()
-    set(${PROJECT_NAME}_CXX_FLAGS "" CACHE STRING "Override all C++ compiler flags")
-    bob_cmake_arg(${PROJECT_NAME}_CXX_FLAGS STRING "")
-    set(${PROJECT_NAME}_EXTRA_CXX_FLAGS "" CACHE STRING "Extra C++ compiler flags")
-    bob_cmake_arg(${PROJECT_NAME}_EXTRA_CXX_FLAGS STRING "")
-    if(${PROJECT_NAME}_CXX_FLAGS)
-      set(FLAGS "${${PROJECT_NAME}_CXX_FLAGS}")
+    set(${BBPCC_VAR_PREFIX}_CXX_FLAGS "" CACHE STRING "Override all C++ compiler flags")
+    bob_cmake_arg(${BBPCC_VAR_PREFIX}_CXX_FLAGS STRING "")
+    set(${BBPCC_VAR_PREFIX}_EXTRA_CXX_FLAGS "" CACHE STRING "Extra C++ compiler flags")
+    bob_cmake_arg(${BBPCC_VAR_PREFIX}_EXTRA_CXX_FLAGS STRING "")
+    if(${BBPCC_VAR_PREFIX}_CXX_FLAGS)
+      set(FLAGS "${${BBPCC_VAR_PREFIX}_CXX_FLAGS}")
     else()
-      set(FLAGS "${CMAKE_CXX_FLAGS} ${BOB_CMAKE_CXX_FLAGS} ${${PROJECT_NAME}_EXTRA_CXX_FLAGS}")
+      set(FLAGS "${CMAKE_CXX_FLAGS} ${BOB_CMAKE_CXX_FLAGS} ${${BBPCC_VAR_PREFIX}_EXTRA_CXX_FLAGS}")
     endif()
     message(STATUS "CMAKE_CXX_FLAGS: ${FLAGS}")
     set(CMAKE_CXX_FLAGS "${FLAGS}" PARENT_SCOPE)
@@ -330,24 +330,24 @@ macro(bob_add_dependency)
   endif()
   if(USE_XSDK_DEFAULTS)
     option(TPL_ENABLE_${ARG_NAME} "Whether to use ${ARG_NAME}"
-           "${${PROJECT_NAME}_USE_${ARG_NAME}_DEFAULT}")
-    bob_cmake_arg(TPL_ENABLE_${ARG_NAME} BOOL "${${PROJECT_NAME}_USE_${ARG_NAME}_DEFAULT}")
-    set(${PROJECT_NAME}_USE_${ARG_NAME} "${TPL_ENABLE_${ARG_NAME}}")
+           "${${BBPCC_VAR_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
+    bob_cmake_arg(TPL_ENABLE_${ARG_NAME} BOOL "${${BBPCC_VAR_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
+    set(${BBPCC_VAR_PREFIX}_USE_${ARG_NAME} "${TPL_ENABLE_${ARG_NAME}}")
     if(TPL_ENABLE_${ARG_NAME})
       set(TPL_${ARG_NAME}_LIBRARIES "" CACHE STRING "${ARG_NAME} libraries")
       bob_cmake_arg(TPL_${ARG_NAME}_LIBRARIES STRING "")
       set(TPL_${ARG_NAME}_INCLUDE_DIRS "" CACHE STRING "${ARG_NAME} include directories")
       bob_cmake_arg(TPL_${ARG_NAME}_INCLUDE_DIRS STRING "")
-      set(tgt "${PROJECT_NAME}-${ARG_NAME}")
+      set(tgt "${BBPCC_VAR_PREFIX}-${ARG_NAME}")
       add_library(${tgt} INTERFACE)
       target_include_directories(${tgt} INTERFACE "${TPL_${ARG_NAME}_INCLUDE_DIRS}")
       target_link_libraries(${tgt} INTERFACE "${TPL_${ARG_NAME}_LIBRARIES}")
     endif()
   else()
-    option(${PROJECT_NAME}_USE_${ARG_NAME} "Whether to use ${ARG_NAME}"
-           ${${PROJECT_NAME}_USE_${ARG_NAME}_DEFAULT})
-    bob_cmake_arg(${PROJECT_NAME}_USE_${ARG_NAME} BOOL "${${PROJECT_NAME}_USE_${ARG_NAME}_DEFAULT}")
-    if(${PROJECT_NAME}_USE_${ARG_NAME})
+    option(${BBPCC_VAR_PREFIX}_USE_${ARG_NAME} "Whether to use ${ARG_NAME}"
+           ${${BBPCC_VAR_PREFIX}_USE_${ARG_NAME}_DEFAULT})
+    bob_cmake_arg(${BBPCC_VAR_PREFIX}_USE_${ARG_NAME} BOOL "${${BBPCC_VAR_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
+    if(${BBPCC_VAR_PREFIX}_USE_${ARG_NAME})
       set(${ARG_NAME}_PREFIX "${${ARG_NAME}_PREFIX_DEFAULT}"
           CACHE PATH "${ARG_NAME} install directory")
       bob_cmake_arg(${ARG_NAME}_PREFIX PATH "${${ARG_NAME}_PREFIX_DEFAULT}")
@@ -369,7 +369,7 @@ macro(bob_add_dependency)
       if(${ARG_NAME}_VERSION)
         message(STATUS "${ARG_NAME}_VERSION: ${${ARG_NAME}_VERSION}")
       endif()
-      set(tgt "${PROJECT_NAME}-${ARG_NAME}")
+      set(tgt "${BBPCC_VAR_PREFIX}-${ARG_NAME}")
       add_library(${tgt} INTERFACE)
       if(ARG_TARGETS)
         target_link_libraries(${tgt} INTERFACE ${ARG_TARGETS})
@@ -392,18 +392,18 @@ macro(bob_add_dependency)
               RUNTIME DESTINATION bin
               ARCHIVE DESTINATION lib
               RUNTIME DESTINATION lib)
-      install(EXPORT ${tgt}-target DESTINATION lib/cmake/${PROJECT_NAME})
-      set(${PROJECT_NAME}_EXPORTED_TARGETS ${${PROJECT_NAME}_EXPORTED_TARGETS} ${tgt})
+      install(EXPORT ${tgt}-target DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
+      set(${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS ${${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS} ${tgt})
       if(ARG_PUBLIC)
-        set(${PROJECT_NAME}_DEPS ${${PROJECT_NAME}_DEPS} ${ARG_NAME})
+        set(${BBPCC_VAR_PREFIX}_DEPS ${${BBPCC_VAR_PREFIX}_DEPS} ${ARG_NAME})
       endif()
     endif()
   endif()
 endmacro(bob_add_dependency)
 
 function(bob_link_dependency tgt type dep)
-  if(${PROJECT_NAME}_USE_${dep})
-    target_link_libraries(${tgt} ${type} ${PROJECT_NAME}-${dep})
+  if(${BBPCC_VAR_PREFIX}_USE_${dep})
+    target_link_libraries(${tgt} ${type} ${BBPCC_VAR_PREFIX}-${dep})
   endif()
 endfunction(bob_link_dependency)
 
@@ -438,10 +438,10 @@ function(bob_export_target tgt_name)
     else()
       install(TARGETS ${tgt_name} EXPORT ${tgt_name}-target DESTINATION lib)
       install(EXPORT ${tgt_name}-target
-              NAMESPACE ${PROJECT_NAME}::
-              DESTINATION lib/cmake/${PROJECT_NAME})
-      set(${PROJECT_NAME}_EXPORTED_TARGETS
-          ${${PROJECT_NAME}_EXPORTED_TARGETS}
+              NAMESPACE ${BBPCC_VAR_PREFIX}::
+              DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
+      set(${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS
+          ${${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS}
           ${tgt_name}
           PARENT_SCOPE)
     endif()
@@ -449,9 +449,9 @@ function(bob_export_target tgt_name)
 endfunction(bob_export_target)
 
 macro(bob_end_subdir)
-  set(${PROJECT_NAME}_EXPORTED_TARGETS ${${PROJECT_NAME}_EXPORTED_TARGETS} PARENT_SCOPE)
-  set(${PROJECT_NAME}_DEPS ${${PROJECT_NAME}_DEPS} PARENT_SCOPE)
-  set(${PROJECT_NAME}_DEP_PREFIXES ${${PROJECT_NAME}_DEP_PREFIXES} PARENT_SCOPE)
+  set(${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS ${${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS} PARENT_SCOPE)
+  set(${BBPCC_VAR_PREFIX}_DEPS ${${BBPCC_VAR_PREFIX}_DEPS} PARENT_SCOPE)
+  set(${BBPCC_VAR_PREFIX}_DEP_PREFIXES ${${BBPCC_VAR_PREFIX}_DEP_PREFIXES} PARENT_SCOPE)
 endmacro(bob_end_subdir)
 
 function(bob_config_header HEADER_PATH)
@@ -464,8 +464,8 @@ function(bob_config_header HEADER_PATH)
   set(HEADER_CONTENT "#ifndef ${INCLUDE_GUARD}
 #define ${INCLUDE_GUARD}
 ")
-  if(${PROJECT_NAME}_KEY_BOOLS)
-    foreach(KEY_BOOL IN LISTS ${PROJECT_NAME}_KEY_BOOLS)
+  if(${BBPCC_VAR_PREFIX}_KEY_BOOLS)
+    foreach(KEY_BOOL IN LISTS ${BBPCC_VAR_PREFIX}_KEY_BOOLS)
       if(${KEY_BOOL})
         string(TOUPPER "${KEY_BOOL}" MACRO_NAME)
         set(HEADER_CONTENT "${HEADER_CONTENT}
@@ -473,15 +473,15 @@ function(bob_config_header HEADER_PATH)
       endif()
     endforeach()
   endif()
-  if(${PROJECT_NAME}_KEY_INTS)
-    foreach(KEY_INT IN LISTS ${PROJECT_NAME}_KEY_INTS)
+  if(${BBPCC_VAR_PREFIX}_KEY_INTS)
+    foreach(KEY_INT IN LISTS ${BBPCC_VAR_PREFIX}_KEY_INTS)
       string(TOUPPER "${KEY_INT}" MACRO_NAME)
       set(HEADER_CONTENT "${HEADER_CONTENT}
 #define ${MACRO_NAME} ${${KEY_INT}}")
     endforeach()
   endif()
-  if(${PROJECT_NAME}_KEY_STRINGS)
-    foreach(KEY_STRING IN LISTS ${PROJECT_NAME}_KEY_STRINGS)
+  if(${BBPCC_VAR_PREFIX}_KEY_STRINGS)
+    foreach(KEY_STRING IN LISTS ${BBPCC_VAR_PREFIX}_KEY_STRINGS)
       string(TOUPPER "${KEY_STRING}" MACRO_NAME)
       set(val "${${KEY_STRING}}")
       # escape escapes
@@ -551,29 +551,29 @@ function(bob_get_link_libs tgt var)
 endfunction()
 
 function(bob_install_provenance)
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_cmake_args.txt
-             "${${PROJECT_NAME}_CMAKE_ARGS}")
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_cmake_args.txt
-          DESTINATION lib/cmake/${PROJECT_NAME})
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_cmake_args.txt
+             "${${BBPCC_VAR_PREFIX}_CMAKE_ARGS}")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_cmake_args.txt
+          DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
   get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
   string(STRIP "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
   string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type_upper)
   foreach(lang IN LISTS languages)
     file(
       WRITE
-        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${lang}_compile_line.txt
+        ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_${lang}_compile_line.txt
         "${CMAKE_${lang}_COMPILER} ${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${build_type_upper}}"
       )
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${lang}_compile_line.txt
-            DESTINATION lib/cmake/${PROJECT_NAME})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_${lang}_compile_line.txt
+            DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
   endforeach()
-  foreach(tgt IN LISTS ${PROJECT_NAME}_EXPORTED_TARGETS)
+  foreach(tgt IN LISTS ${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS)
     get_target_property(tgt_type "${tgt}" TYPE)
     if(tgt_type MATCHES "STATIC_LIBRARY|SHARED_LIBRARY")
       bob_get_link_libs(${tgt} link_libs)
-      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${tgt}_libs.txt "${link_libs}")
-      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${tgt}_libs.txt
-              DESTINATION lib/cmake/${PROJECT_NAME})
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_${tgt}_libs.txt "${link_libs}")
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_${tgt}_libs.txt
+              DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
     endif()
   endforeach()
 endfunction(bob_install_provenance)
@@ -622,7 +622,7 @@ macro(latest_find_dependency dep)
   endif()
 endmacro(latest_find_dependency)")
   set(FIND_DEPS_CONTENT)
-  foreach(dep IN LISTS ${PROJECT_NAME}_DEPS)
+  foreach(dep IN LISTS ${BBPCC_VAR_PREFIX}_DEPS)
     string(REPLACE ";"
                    " "
                    FIND_DEP_ARGS
@@ -630,16 +630,16 @@ endmacro(latest_find_dependency)")
     set(FIND_DEPS_CONTENT "${FIND_DEPS_CONTENT}
 latest_find_dependency(${dep} ${FIND_DEP_ARGS})")
   endforeach()
-  set(CONFIG_CONTENT "set(${PROJECT_NAME}_VERSION ${${PROJECT_NAME}_VERSION})
+  set(CONFIG_CONTENT "set(${BBPCC_VAR_PREFIX}_VERSION ${${BBPCC_VAR_PREFIX}_VERSION})
 ${LATEST_FIND_DEPENDENCY}
 ${FIND_DEPS_CONTENT}
-set(${PROJECT_NAME}_EXPORTED_TARGETS \"${${PROJECT_NAME}_EXPORTED_TARGETS}\")
-foreach(tgt IN LISTS ${PROJECT_NAME}_EXPORTED_TARGETS)
+set(${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS \"${${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS}\")
+foreach(tgt IN LISTS ${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS)
   include(\${CMAKE_CURRENT_LIST_DIR}/\${tgt}-target.cmake)
 endforeach()")
   foreach(TYPE IN ITEMS "BOOL" "INT" "STRING")
-    if(${PROJECT_NAME}_KEY_${TYPE}S)
-      foreach(KEY_${TYPE} IN LISTS ${PROJECT_NAME}_KEY_${TYPE}S)
+    if(${BBPCC_VAR_PREFIX}_KEY_${TYPE}S)
+      foreach(KEY_${TYPE} IN LISTS ${BBPCC_VAR_PREFIX}_KEY_${TYPE}S)
         set(val "${${KEY_${TYPE}}}")
         # escape escapes
         string(REPLACE "\\"
@@ -658,15 +658,15 @@ set(${KEY_${TYPE}} \"${val}\")")
   endforeach()
   set(CONFIG_CONTENT "${CONFIG_CONTENT}
 ")
-  install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-          DESTINATION lib/cmake/${PROJECT_NAME})
+  install(FILES "${PROJECT_BINARY_DIR}/${BBPCC_VAR_PREFIX}Config.cmake"
+          DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
   if(PROJECT_VERSION)
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake "${CONFIG_CONTENT}")
-    write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}Config.cmake "${CONFIG_CONTENT}")
+    write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}ConfigVersion.cmake
                                      VERSION ${PROJECT_VERSION}
                                      COMPATIBILITY SameMajorVersion)
-    install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-            DESTINATION lib/cmake/${PROJECT_NAME})
+    install(FILES "${PROJECT_BINARY_DIR}/${BBPCC_VAR_PREFIX}ConfigVersion.cmake"
+            DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
   endif()
   bob_install_provenance()
 endfunction(bob_end_package)

--- a/cpp/cmake/bob.cmake
+++ b/cpp/cmake/bob.cmake
@@ -17,13 +17,13 @@ endfunction(bob_always_full_rpath)
 
 function(bob_cmake_arg2 var type default)
   if(NOT ${var} STREQUAL "${default}")
-    if(${BBPCC_VAR_PREFIX}_CMAKE_ARGS)
+    if(${CODING_CONV_PREFIX}_CMAKE_ARGS)
       set(sep " ")
     else()
       set(sep "")
     endif()
-    set(${BBPCC_VAR_PREFIX}_CMAKE_ARGS
-        "${${BBPCC_VAR_PREFIX}_CMAKE_ARGS}${sep}-D${var}:${type}=\"${${var}}\""
+    set(${CODING_CONV_PREFIX}_CMAKE_ARGS
+        "${${CODING_CONV_PREFIX}_CMAKE_ARGS}${sep}-D${var}:${type}=\"${${var}}\""
         CACHE STRING "CMake arguments that would replicate this configuration"
         FORCE)
   endif()
@@ -45,12 +45,12 @@ function(bob_input var default type desc)
 endfunction()
 
 macro(bob_begin_package)
-  set(${BBPCC_VAR_PREFIX}_CMAKE_ARGS ""
+  set(${CODING_CONV_PREFIX}_CMAKE_ARGS ""
       CACHE STRING "CMake arguments that would replicate this configuration"
       FORCE)
   message(STATUS "CMAKE_VERSION: ${CMAKE_VERSION}")
-  if(${BBPCC_VAR_PREFIX}_VERSION)
-    message(STATUS "${BBPCC_VAR_PREFIX}_VERSION: ${${BBPCC_VAR_PREFIX}_VERSION}")
+  if(${CODING_CONV_PREFIX}_VERSION)
+    message(STATUS "${CODING_CONV_PREFIX}_VERSION: ${${CODING_CONV_PREFIX}_VERSION}")
   endif()
   option(USE_XSDK_DEFAULTS "enable the XDSK v0.3.0 default configuration" OFF)
   bob_cmake_arg(USE_XSDK_DEFAULTS BOOL OFF)
@@ -76,7 +76,7 @@ macro(bob_begin_package)
   bob_cmake_arg(BUILD_TESTING BOOL OFF)
   bob_cmake_arg(BUILD_SHARED_LIBS BOOL ON)
   bob_cmake_arg(CMAKE_INSTALL_PREFIX PATH "")
-  option(${BBPCC_VAR_PREFIX}_NORMAL_CXX_FLAGS
+  option(${CODING_CONV_PREFIX}_NORMAL_CXX_FLAGS
          "Allow CMAKE_CXX_FLAGS to follow \"normal\" CMake behavior" ${USE_XSDK_DEFAULTS})
 endmacro(bob_begin_package)
 
@@ -90,7 +90,7 @@ function(bob_get_commit)
   if(NO_SHA1)
     message(WARNING "bob_get_commit: no Git hash!\n" ${SHA1_ERROR})
   else()
-    set(${BBPCC_VAR_PREFIX}_COMMIT "${SHA1}" PARENT_SCOPE)
+    set(${CODING_CONV_PREFIX}_COMMIT "${SHA1}" PARENT_SCOPE)
   endif()
 endfunction(bob_get_commit)
 
@@ -102,8 +102,8 @@ function(bob_get_semver)
                   ERROR_VARIABLE TAG_ERROR
                   OUTPUT_STRIP_TRAILING_WHITESPACE)
   if(NOT_TAG)
-    if(${BBPCC_VAR_PREFIX}_VERSION)
-      set(SEMVER ${${BBPCC_VAR_PREFIX}_VERSION})
+    if(${CODING_CONV_PREFIX}_VERSION)
+      set(SEMVER ${${CODING_CONV_PREFIX}_VERSION})
       execute_process(COMMAND git log -1 --format=%h
                       WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                       RESULT_VARIABLE NO_SHA1
@@ -116,7 +116,7 @@ function(bob_get_semver)
         set(SEMVER "${SEMVER}-sha.${SHORT_SHA1}")
       endif()
     else()
-      message(FATAL_ERROR "bob_get_semver needs either ${BBPCC_VAR_PREFIX}_VERSION or a Git tag\n"
+      message(FATAL_ERROR "bob_get_semver needs either ${CODING_CONV_PREFIX}_VERSION or a Git tag\n"
                           ${TAG_ERROR})
     endif()
   else()
@@ -125,25 +125,25 @@ function(bob_get_semver)
                        1
                        -1
                        SEMVER)
-      if(${BBPCC_VAR_PREFIX}_VERSION AND (NOT (SEMVER VERSION_EQUAL ${BBPCC_VAR_PREFIX}_VERSION)))
+      if(${CODING_CONV_PREFIX}_VERSION AND (NOT (SEMVER VERSION_EQUAL ${CODING_CONV_PREFIX}_VERSION)))
         message(
           FATAL_ERROR
-            "bob_get_semver: tag is ${TAG_NAME} but ${BBPCC_VAR_PREFIX}_VERSION=${${BBPCC_VAR_PREFIX}_VERSION} !"
+            "bob_get_semver: tag is ${TAG_NAME} but ${CODING_CONV_PREFIX}_VERSION=${${CODING_CONV_PREFIX}_VERSION} !"
           )
       endif()
     else()
-      if(${BBPCC_VAR_PREFIX}_VERSION)
-        set(SEMVER "${${BBPCC_VAR_PREFIX}_VERSION}-tag.${TAG_NAME}")
+      if(${CODING_CONV_PREFIX}_VERSION)
+        set(SEMVER "${${CODING_CONV_PREFIX}_VERSION}-tag.${TAG_NAME}")
       else()
         message(
           FATAL_ERROR
-            "bob_get_semver needs either ${BBPCC_VAR_PREFIX}_VERSION or a Git tag of the form v1.2.3")
+            "bob_get_semver needs either ${CODING_CONV_PREFIX}_VERSION or a Git tag of the form v1.2.3")
       endif()
     endif()
   endif()
-  if(${BBPCC_VAR_PREFIX}_KEY_BOOLS)
+  if(${CODING_CONV_PREFIX}_KEY_BOOLS)
     set(SEMVER "${SEMVER}+")
-    foreach(KEY_BOOL IN LISTS ${BBPCC_VAR_PREFIX}_KEY_BOOLS)
+    foreach(KEY_BOOL IN LISTS ${CODING_CONV_PREFIX}_KEY_BOOLS)
       if(${KEY_BOOL})
         set(SEMVER "${SEMVER}1")
       else()
@@ -151,8 +151,8 @@ function(bob_get_semver)
       endif()
     endforeach()
   endif()
-  set(${BBPCC_VAR_PREFIX}_SEMVER "${SEMVER}" PARENT_SCOPE)
-  message(STATUS "${BBPCC_VAR_PREFIX}_SEMVER = ${SEMVER}")
+  set(${CODING_CONV_PREFIX}_SEMVER "${SEMVER}" PARENT_SCOPE)
+  message(STATUS "${CODING_CONV_PREFIX}_SEMVER = ${SEMVER}")
 endfunction(bob_get_semver)
 
 function(bob_cxx_pedantic_flags)
@@ -225,7 +225,7 @@ function(bob_cxx_pedantic_flags)
 endfunction(bob_cxx_pedantic_flags)
 
 function(bob_begin_cxx_flags)
-  if(${BBPCC_VAR_PREFIX}_NORMAL_CXX_FLAGS)
+  if(${CODING_CONV_PREFIX}_NORMAL_CXX_FLAGS)
     set(BOB_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
     bob_cmake_arg2(CMAKE_CXX_FLAGS STRING "")
   else()
@@ -233,34 +233,34 @@ function(bob_begin_cxx_flags)
     if(CMAKE_BUILD_TYPE)
       message(FATAL_ERROR "can't set CMAKE_BUILD_TYPE and use bob_*_cxx_flags")
     endif()
-    option(${BBPCC_VAR_PREFIX}_CXX_OPTIMIZE "Compile C++ with optimization" ON)
-    option(${BBPCC_VAR_PREFIX}_CXX_SYMBOLS "Compile C++ with debug symbols" ON)
-    option(${BBPCC_VAR_PREFIX}_CXX_WARNINGS "Compile C++ with warnings" ON)
-    bob_cmake_arg(${BBPCC_VAR_PREFIX}_CXX_OPTIMIZE BOOL ON)
-    bob_cmake_arg(${BBPCC_VAR_PREFIX}_CXX_SYMBOLS BOOL ON)
-    set(${BBPCC_VAR_PREFIX}_ARCH "" CACHE STRING "Argument to -march or -arch")
-    bob_cmake_arg(${BBPCC_VAR_PREFIX}_ARCH STRING "native")
+    option(${CODING_CONV_PREFIX}_CXX_OPTIMIZE "Compile C++ with optimization" ON)
+    option(${CODING_CONV_PREFIX}_CXX_SYMBOLS "Compile C++ with debug symbols" ON)
+    option(${CODING_CONV_PREFIX}_CXX_WARNINGS "Compile C++ with warnings" ON)
+    bob_cmake_arg(${CODING_CONV_PREFIX}_CXX_OPTIMIZE BOOL ON)
+    bob_cmake_arg(${CODING_CONV_PREFIX}_CXX_SYMBOLS BOOL ON)
+    set(${CODING_CONV_PREFIX}_ARCH "" CACHE STRING "Argument to -march or -arch")
+    bob_cmake_arg(${CODING_CONV_PREFIX}_ARCH STRING "native")
     # CDash's simple output parser interprets the variable name WARNINGS as a warning...
-    message(STATUS "${BBPCC_VAR_PREFIX}_CXX_W**NINGS: ${${BBPCC_VAR_PREFIX}_CXX_WARNINGS}")
-    bob_cmake_arg2(${BBPCC_VAR_PREFIX}_CXX_WARNINGS BOOL ON)
+    message(STATUS "${CODING_CONV_PREFIX}_CXX_W**NINGS: ${${CODING_CONV_PREFIX}_CXX_WARNINGS}")
+    bob_cmake_arg2(${CODING_CONV_PREFIX}_CXX_WARNINGS BOOL ON)
     set(FLAGS "")
-    if(${BBPCC_VAR_PREFIX}_CXX_OPTIMIZE)
+    if(${CODING_CONV_PREFIX}_CXX_OPTIMIZE)
       set(FLAGS "${FLAGS} -O3 -DNDEBUG")
-      if(${BBPCC_VAR_PREFIX}_ARCH)
-        if(${BBPCC_VAR_PREFIX}_USE_CUDA)
-          set(FLAGS "${FLAGS} -arch=${${BBPCC_VAR_PREFIX}_ARCH}")
+      if(${CODING_CONV_PREFIX}_ARCH)
+        if(${CODING_CONV_PREFIX}_USE_CUDA)
+          set(FLAGS "${FLAGS} -arch=${${CODING_CONV_PREFIX}_ARCH}")
         else()
-          set(FLAGS "${FLAGS} -march=${${BBPCC_VAR_PREFIX}_ARCH}")
+          set(FLAGS "${FLAGS} -march=${${CODING_CONV_PREFIX}_ARCH}")
         endif()
       endif()
     else()
       set(FLAGS "${FLAGS} -O0")
     endif()
-    if(${BBPCC_VAR_PREFIX}_CXX_SYMBOLS)
+    if(${CODING_CONV_PREFIX}_CXX_SYMBOLS)
       set(FLAGS "${FLAGS} -g")
     endif()
     # -----------
-    if(${BBPCC_VAR_PREFIX}_CXX_WARNINGS)
+    if(${CODING_CONV_PREFIX}_CXX_WARNINGS)
       bob_cxx_pedantic_flags(FLAGS)
     endif()
     set(BOB_CMAKE_CXX_FLAGS "${FLAGS}" PARENT_SCOPE)
@@ -269,7 +269,7 @@ endfunction(bob_begin_cxx_flags)
 
 macro(bob_cxx_standard_flags standard)
   if(NOT standard VERSION_EQUAL 98 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    if(${BBPCC_VAR_PREFIX}_CXX_WARNINGS)
+    if(${CODING_CONV_PREFIX}_CXX_WARNINGS)
       set(BOB_CMAKE_CXX_FLAGS "${BOB_CMAKE_CXX_FLAGS} -Wno-c++98-compat-pedantic -Wno-c++98-compat"
           PARENT_SCOPE)
     endif()
@@ -296,18 +296,18 @@ function(bob_cxx20_flags)
 endfunction(bob_cxx20_flags)
 
 function(bob_end_cxx_flags)
-  if(${BBPCC_VAR_PREFIX}_NORMAL_CXX_FLAGS)
+  if(${CODING_CONV_PREFIX}_NORMAL_CXX_FLAGS)
     message(STATUS "CMAKE_CXX_FLAGS: ${BOB_CMAKE_CXX_FLAGS}")
     set(CMAKE_CXX_FLAGS "${BOB_CMAKE_CXX_FLAGS}" PARENT_SCOPE)
   else()
-    set(${BBPCC_VAR_PREFIX}_CXX_FLAGS "" CACHE STRING "Override all C++ compiler flags")
-    bob_cmake_arg(${BBPCC_VAR_PREFIX}_CXX_FLAGS STRING "")
-    set(${BBPCC_VAR_PREFIX}_EXTRA_CXX_FLAGS "" CACHE STRING "Extra C++ compiler flags")
-    bob_cmake_arg(${BBPCC_VAR_PREFIX}_EXTRA_CXX_FLAGS STRING "")
-    if(${BBPCC_VAR_PREFIX}_CXX_FLAGS)
-      set(FLAGS "${${BBPCC_VAR_PREFIX}_CXX_FLAGS}")
+    set(${CODING_CONV_PREFIX}_CXX_FLAGS "" CACHE STRING "Override all C++ compiler flags")
+    bob_cmake_arg(${CODING_CONV_PREFIX}_CXX_FLAGS STRING "")
+    set(${CODING_CONV_PREFIX}_EXTRA_CXX_FLAGS "" CACHE STRING "Extra C++ compiler flags")
+    bob_cmake_arg(${CODING_CONV_PREFIX}_EXTRA_CXX_FLAGS STRING "")
+    if(${CODING_CONV_PREFIX}_CXX_FLAGS)
+      set(FLAGS "${${CODING_CONV_PREFIX}_CXX_FLAGS}")
     else()
-      set(FLAGS "${CMAKE_CXX_FLAGS} ${BOB_CMAKE_CXX_FLAGS} ${${BBPCC_VAR_PREFIX}_EXTRA_CXX_FLAGS}")
+      set(FLAGS "${CMAKE_CXX_FLAGS} ${BOB_CMAKE_CXX_FLAGS} ${${CODING_CONV_PREFIX}_EXTRA_CXX_FLAGS}")
     endif()
     message(STATUS "CMAKE_CXX_FLAGS: ${FLAGS}")
     set(CMAKE_CXX_FLAGS "${FLAGS}" PARENT_SCOPE)
@@ -330,24 +330,24 @@ macro(bob_add_dependency)
   endif()
   if(USE_XSDK_DEFAULTS)
     option(TPL_ENABLE_${ARG_NAME} "Whether to use ${ARG_NAME}"
-           "${${BBPCC_VAR_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
-    bob_cmake_arg(TPL_ENABLE_${ARG_NAME} BOOL "${${BBPCC_VAR_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
-    set(${BBPCC_VAR_PREFIX}_USE_${ARG_NAME} "${TPL_ENABLE_${ARG_NAME}}")
+           "${${CODING_CONV_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
+    bob_cmake_arg(TPL_ENABLE_${ARG_NAME} BOOL "${${CODING_CONV_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
+    set(${CODING_CONV_PREFIX}_USE_${ARG_NAME} "${TPL_ENABLE_${ARG_NAME}}")
     if(TPL_ENABLE_${ARG_NAME})
       set(TPL_${ARG_NAME}_LIBRARIES "" CACHE STRING "${ARG_NAME} libraries")
       bob_cmake_arg(TPL_${ARG_NAME}_LIBRARIES STRING "")
       set(TPL_${ARG_NAME}_INCLUDE_DIRS "" CACHE STRING "${ARG_NAME} include directories")
       bob_cmake_arg(TPL_${ARG_NAME}_INCLUDE_DIRS STRING "")
-      set(tgt "${BBPCC_VAR_PREFIX}-${ARG_NAME}")
+      set(tgt "${CODING_CONV_PREFIX}-${ARG_NAME}")
       add_library(${tgt} INTERFACE)
       target_include_directories(${tgt} INTERFACE "${TPL_${ARG_NAME}_INCLUDE_DIRS}")
       target_link_libraries(${tgt} INTERFACE "${TPL_${ARG_NAME}_LIBRARIES}")
     endif()
   else()
-    option(${BBPCC_VAR_PREFIX}_USE_${ARG_NAME} "Whether to use ${ARG_NAME}"
-           ${${BBPCC_VAR_PREFIX}_USE_${ARG_NAME}_DEFAULT})
-    bob_cmake_arg(${BBPCC_VAR_PREFIX}_USE_${ARG_NAME} BOOL "${${BBPCC_VAR_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
-    if(${BBPCC_VAR_PREFIX}_USE_${ARG_NAME})
+    option(${CODING_CONV_PREFIX}_USE_${ARG_NAME} "Whether to use ${ARG_NAME}"
+           ${${CODING_CONV_PREFIX}_USE_${ARG_NAME}_DEFAULT})
+    bob_cmake_arg(${CODING_CONV_PREFIX}_USE_${ARG_NAME} BOOL "${${CODING_CONV_PREFIX}_USE_${ARG_NAME}_DEFAULT}")
+    if(${CODING_CONV_PREFIX}_USE_${ARG_NAME})
       set(${ARG_NAME}_PREFIX "${${ARG_NAME}_PREFIX_DEFAULT}"
           CACHE PATH "${ARG_NAME} install directory")
       bob_cmake_arg(${ARG_NAME}_PREFIX PATH "${${ARG_NAME}_PREFIX_DEFAULT}")
@@ -369,7 +369,7 @@ macro(bob_add_dependency)
       if(${ARG_NAME}_VERSION)
         message(STATUS "${ARG_NAME}_VERSION: ${${ARG_NAME}_VERSION}")
       endif()
-      set(tgt "${BBPCC_VAR_PREFIX}-${ARG_NAME}")
+      set(tgt "${CODING_CONV_PREFIX}-${ARG_NAME}")
       add_library(${tgt} INTERFACE)
       if(ARG_TARGETS)
         target_link_libraries(${tgt} INTERFACE ${ARG_TARGETS})
@@ -392,18 +392,18 @@ macro(bob_add_dependency)
               RUNTIME DESTINATION bin
               ARCHIVE DESTINATION lib
               RUNTIME DESTINATION lib)
-      install(EXPORT ${tgt}-target DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
-      set(${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS ${${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS} ${tgt})
+      install(EXPORT ${tgt}-target DESTINATION lib/cmake/${CODING_CONV_PREFIX})
+      set(${CODING_CONV_PREFIX}_EXPORTED_TARGETS ${${CODING_CONV_PREFIX}_EXPORTED_TARGETS} ${tgt})
       if(ARG_PUBLIC)
-        set(${BBPCC_VAR_PREFIX}_DEPS ${${BBPCC_VAR_PREFIX}_DEPS} ${ARG_NAME})
+        set(${CODING_CONV_PREFIX}_DEPS ${${CODING_CONV_PREFIX}_DEPS} ${ARG_NAME})
       endif()
     endif()
   endif()
 endmacro(bob_add_dependency)
 
 function(bob_link_dependency tgt type dep)
-  if(${BBPCC_VAR_PREFIX}_USE_${dep})
-    target_link_libraries(${tgt} ${type} ${BBPCC_VAR_PREFIX}-${dep})
+  if(${CODING_CONV_PREFIX}_USE_${dep})
+    target_link_libraries(${tgt} ${type} ${CODING_CONV_PREFIX}-${dep})
   endif()
 endfunction(bob_link_dependency)
 
@@ -438,10 +438,10 @@ function(bob_export_target tgt_name)
     else()
       install(TARGETS ${tgt_name} EXPORT ${tgt_name}-target DESTINATION lib)
       install(EXPORT ${tgt_name}-target
-              NAMESPACE ${BBPCC_VAR_PREFIX}::
-              DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
-      set(${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS
-          ${${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS}
+              NAMESPACE ${CODING_CONV_PREFIX}::
+              DESTINATION lib/cmake/${CODING_CONV_PREFIX})
+      set(${CODING_CONV_PREFIX}_EXPORTED_TARGETS
+          ${${CODING_CONV_PREFIX}_EXPORTED_TARGETS}
           ${tgt_name}
           PARENT_SCOPE)
     endif()
@@ -449,9 +449,9 @@ function(bob_export_target tgt_name)
 endfunction(bob_export_target)
 
 macro(bob_end_subdir)
-  set(${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS ${${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS} PARENT_SCOPE)
-  set(${BBPCC_VAR_PREFIX}_DEPS ${${BBPCC_VAR_PREFIX}_DEPS} PARENT_SCOPE)
-  set(${BBPCC_VAR_PREFIX}_DEP_PREFIXES ${${BBPCC_VAR_PREFIX}_DEP_PREFIXES} PARENT_SCOPE)
+  set(${CODING_CONV_PREFIX}_EXPORTED_TARGETS ${${CODING_CONV_PREFIX}_EXPORTED_TARGETS} PARENT_SCOPE)
+  set(${CODING_CONV_PREFIX}_DEPS ${${CODING_CONV_PREFIX}_DEPS} PARENT_SCOPE)
+  set(${CODING_CONV_PREFIX}_DEP_PREFIXES ${${CODING_CONV_PREFIX}_DEP_PREFIXES} PARENT_SCOPE)
 endmacro(bob_end_subdir)
 
 function(bob_config_header HEADER_PATH)
@@ -464,8 +464,8 @@ function(bob_config_header HEADER_PATH)
   set(HEADER_CONTENT "#ifndef ${INCLUDE_GUARD}
 #define ${INCLUDE_GUARD}
 ")
-  if(${BBPCC_VAR_PREFIX}_KEY_BOOLS)
-    foreach(KEY_BOOL IN LISTS ${BBPCC_VAR_PREFIX}_KEY_BOOLS)
+  if(${CODING_CONV_PREFIX}_KEY_BOOLS)
+    foreach(KEY_BOOL IN LISTS ${CODING_CONV_PREFIX}_KEY_BOOLS)
       if(${KEY_BOOL})
         string(TOUPPER "${KEY_BOOL}" MACRO_NAME)
         set(HEADER_CONTENT "${HEADER_CONTENT}
@@ -473,15 +473,15 @@ function(bob_config_header HEADER_PATH)
       endif()
     endforeach()
   endif()
-  if(${BBPCC_VAR_PREFIX}_KEY_INTS)
-    foreach(KEY_INT IN LISTS ${BBPCC_VAR_PREFIX}_KEY_INTS)
+  if(${CODING_CONV_PREFIX}_KEY_INTS)
+    foreach(KEY_INT IN LISTS ${CODING_CONV_PREFIX}_KEY_INTS)
       string(TOUPPER "${KEY_INT}" MACRO_NAME)
       set(HEADER_CONTENT "${HEADER_CONTENT}
 #define ${MACRO_NAME} ${${KEY_INT}}")
     endforeach()
   endif()
-  if(${BBPCC_VAR_PREFIX}_KEY_STRINGS)
-    foreach(KEY_STRING IN LISTS ${BBPCC_VAR_PREFIX}_KEY_STRINGS)
+  if(${CODING_CONV_PREFIX}_KEY_STRINGS)
+    foreach(KEY_STRING IN LISTS ${CODING_CONV_PREFIX}_KEY_STRINGS)
       string(TOUPPER "${KEY_STRING}" MACRO_NAME)
       set(val "${${KEY_STRING}}")
       # escape escapes
@@ -551,29 +551,29 @@ function(bob_get_link_libs tgt var)
 endfunction()
 
 function(bob_install_provenance)
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_cmake_args.txt
-             "${${BBPCC_VAR_PREFIX}_CMAKE_ARGS}")
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_cmake_args.txt
-          DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${CODING_CONV_PREFIX}_cmake_args.txt
+             "${${CODING_CONV_PREFIX}_CMAKE_ARGS}")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CODING_CONV_PREFIX}_cmake_args.txt
+          DESTINATION lib/cmake/${CODING_CONV_PREFIX})
   get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
   string(STRIP "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
   string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type_upper)
   foreach(lang IN LISTS languages)
     file(
       WRITE
-        ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_${lang}_compile_line.txt
+        ${CMAKE_CURRENT_BINARY_DIR}/${CODING_CONV_PREFIX}_${lang}_compile_line.txt
         "${CMAKE_${lang}_COMPILER} ${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${build_type_upper}}"
       )
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_${lang}_compile_line.txt
-            DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CODING_CONV_PREFIX}_${lang}_compile_line.txt
+            DESTINATION lib/cmake/${CODING_CONV_PREFIX})
   endforeach()
-  foreach(tgt IN LISTS ${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS)
+  foreach(tgt IN LISTS ${CODING_CONV_PREFIX}_EXPORTED_TARGETS)
     get_target_property(tgt_type "${tgt}" TYPE)
     if(tgt_type MATCHES "STATIC_LIBRARY|SHARED_LIBRARY")
       bob_get_link_libs(${tgt} link_libs)
-      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_${tgt}_libs.txt "${link_libs}")
-      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}_${tgt}_libs.txt
-              DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
+      file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${CODING_CONV_PREFIX}_${tgt}_libs.txt "${link_libs}")
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${CODING_CONV_PREFIX}_${tgt}_libs.txt
+              DESTINATION lib/cmake/${CODING_CONV_PREFIX})
     endif()
   endforeach()
 endfunction(bob_install_provenance)
@@ -622,7 +622,7 @@ macro(latest_find_dependency dep)
   endif()
 endmacro(latest_find_dependency)")
   set(FIND_DEPS_CONTENT)
-  foreach(dep IN LISTS ${BBPCC_VAR_PREFIX}_DEPS)
+  foreach(dep IN LISTS ${CODING_CONV_PREFIX}_DEPS)
     string(REPLACE ";"
                    " "
                    FIND_DEP_ARGS
@@ -630,16 +630,16 @@ endmacro(latest_find_dependency)")
     set(FIND_DEPS_CONTENT "${FIND_DEPS_CONTENT}
 latest_find_dependency(${dep} ${FIND_DEP_ARGS})")
   endforeach()
-  set(CONFIG_CONTENT "set(${BBPCC_VAR_PREFIX}_VERSION ${${BBPCC_VAR_PREFIX}_VERSION})
+  set(CONFIG_CONTENT "set(${CODING_CONV_PREFIX}_VERSION ${${CODING_CONV_PREFIX}_VERSION})
 ${LATEST_FIND_DEPENDENCY}
 ${FIND_DEPS_CONTENT}
-set(${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS \"${${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS}\")
-foreach(tgt IN LISTS ${BBPCC_VAR_PREFIX}_EXPORTED_TARGETS)
+set(${CODING_CONV_PREFIX}_EXPORTED_TARGETS \"${${CODING_CONV_PREFIX}_EXPORTED_TARGETS}\")
+foreach(tgt IN LISTS ${CODING_CONV_PREFIX}_EXPORTED_TARGETS)
   include(\${CMAKE_CURRENT_LIST_DIR}/\${tgt}-target.cmake)
 endforeach()")
   foreach(TYPE IN ITEMS "BOOL" "INT" "STRING")
-    if(${BBPCC_VAR_PREFIX}_KEY_${TYPE}S)
-      foreach(KEY_${TYPE} IN LISTS ${BBPCC_VAR_PREFIX}_KEY_${TYPE}S)
+    if(${CODING_CONV_PREFIX}_KEY_${TYPE}S)
+      foreach(KEY_${TYPE} IN LISTS ${CODING_CONV_PREFIX}_KEY_${TYPE}S)
         set(val "${${KEY_${TYPE}}}")
         # escape escapes
         string(REPLACE "\\"
@@ -658,15 +658,15 @@ set(${KEY_${TYPE}} \"${val}\")")
   endforeach()
   set(CONFIG_CONTENT "${CONFIG_CONTENT}
 ")
-  install(FILES "${PROJECT_BINARY_DIR}/${BBPCC_VAR_PREFIX}Config.cmake"
-          DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
+  install(FILES "${PROJECT_BINARY_DIR}/${CODING_CONV_PREFIX}Config.cmake"
+          DESTINATION lib/cmake/${CODING_CONV_PREFIX})
   if(PROJECT_VERSION)
-    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}Config.cmake "${CONFIG_CONTENT}")
-    write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${BBPCC_VAR_PREFIX}ConfigVersion.cmake
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${CODING_CONV_PREFIX}Config.cmake "${CONFIG_CONTENT}")
+    write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${CODING_CONV_PREFIX}ConfigVersion.cmake
                                      VERSION ${PROJECT_VERSION}
                                      COMPATIBILITY SameMajorVersion)
-    install(FILES "${PROJECT_BINARY_DIR}/${BBPCC_VAR_PREFIX}ConfigVersion.cmake"
-            DESTINATION lib/cmake/${BBPCC_VAR_PREFIX})
+    install(FILES "${PROJECT_BINARY_DIR}/${CODING_CONV_PREFIX}ConfigVersion.cmake"
+            DESTINATION lib/cmake/${CODING_CONV_PREFIX})
   endif()
   bob_install_provenance()
 endfunction(bob_end_package)


### PR DESCRIPTION
in some projects, the `${PROJECT_NAME}` variable differs from what we
ususally have as the prefix for cmake options. For example:

- CoreNEURON: The cmake `${PROJECT_NAME}` is `coreneuron` but we use `CORENRN` for all other options.
- NEURON: the project name is NEURON, but we use `NRN` in many places in the code.

This change allows the programmer to define their own prefix, which can later be used for the
variables when building the project.