### PR TITLE
Fix configuration of Standard for clang-format 10 and 11

### DIFF
--- a/cpp/.clang-format-10
+++ b/cpp/.clang-format-10
@@ -86,7 +86,7 @@ SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false # '(' style
 SpacesInSquareBrackets: false
-Standard: Cpp14
+Standard: c++14
 TabWidth: 4
 UseTab: Never
 ...

--- a/cpp/.clang-format-11
+++ b/cpp/.clang-format-11
@@ -86,7 +86,7 @@ SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false # '(' style
 SpacesInSquareBrackets: false
-Standard: Cpp14
+Standard: c++14
 TabWidth: 4
 UseTab: Never
 ...


### PR DESCRIPTION
Following: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
Cpp11 means Latest and is deprecated.
If you want a specific version you have to use c++11 / c++14 / ...