### PR TITLE
make_cpp_file_filter: fix if binary_dir is source_dir

### DIFF
--- a/cpp/cmake/cpplib.py
+++ b/cpp/cmake/cpplib.py
@@ -90,7 +90,7 @@ def make_cpp_file_filter(source_dir, binary_dir, excludes_re, files_re):
     def _func(cpp_file):
         if not cpp_file.startswith(source_dir):
             return True
-        if cpp_file.startswith(binary_dir):
+        if binary_dir != source_dir and cpp_file.startswith(binary_dir):
             return True
         # exclude some paths available in CI environment
         for ci_dir in ["HOME", "INSTALL"]:


### PR DESCRIPTION
This is a partial fix, because if binary_dir is a parent of source_dir it will not work.
Hopefully no one will try to do such crazy things