### PR TITLE
Add support for git push hooks / add hook to print courtesy message

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -7,20 +7,36 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS
     PARENT_SCOPE)
 if(NOT CODING_CONV_PREFIX)
   set(CODING_CONV_PREFIX "${PROJECT_NAME}")
-  set(CODING_CONV_PREFIX "${PROJECT_NAME}" PARENT_SCOPE)
+  set(CODING_CONV_PREFIX
+      "${PROJECT_NAME}"
+      PARENT_SCOPE)
 endif(NOT CODING_CONV_PREFIX)
 include(cmake/bob.cmake)
 
 function(bbp_enable_precommit)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(PreCommit REQUIRED)
-  execute_process(COMMAND ${PreCommit_EXECUTABLE} install)
+  if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)
+    execute_process(COMMAND ${PreCommit_EXECUTABLE} install)
+  endif()
+  if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-push)
+    execute_process(COMMAND ${PreCommit_EXECUTABLE} install --hook-type pre-push)
+  endif()
+  if(${CODING_CONV_PREFIX}_GIT_COMMIT_HOOKS MATCHES "courtesy-msg"
+     OR ${CODING_CONV_PREFIX}_GIT_PUSH_HOOKS MATCHES "courtesy-msg")
+    if(EXISTS ${PROJECT_SOURCE_DIR}/.git-push-message.cmake.in)
+      configure_file(${PROJECT_SOURCE_DIR}/.git-push-message.cmake.in
+                     ${PROJECT_BINARY_DIR}/git-push-message.cmake @ONLY)
+    else()
+      configure_file(cmake/git-push-message.cmake.in ${PROJECT_BINARY_DIR}/git-push-message.cmake
+                     @ONLY)
+    endif()
+  endif()
   execute_process(
     COMMAND
       ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
-      --force ${${CODING_CONV_PREFIX}_PRECOMMIT_REGEN} --clang-format
-      ${${CODING_CONV_PREFIX}_FORMATTING} --cmake-format ${${CODING_CONV_PREFIX}_FORMATTING}
-      --clang-tidy ${${CODING_CONV_PREFIX}_STATIC_ANALYSIS} ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
+      --commit-checks=${${CODING_CONV_PREFIX}_GIT_COMMIT_HOOKS}
+      --push-checks=${${CODING_CONV_PREFIX}_GIT_PUSH_HOOKS} ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   add_custom_target(git-pre-commits ${PreCommit_EXECUTABLE} run --all-files)
 endfunction(bbp_enable_precommit)
 
@@ -28,11 +44,11 @@ function(bbp_disable_precommit)
   if(EXISTS ${CMAKE_SOURCE_DIR}/.pre-commit-config.yaml)
     find_package(PythonInterp 3.5 REQUIRED)
     execute_process(
-      COMMAND
-        ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py"
-        --clang-format off --cmake-format off --clang-tidy off ${CMAKE_SOURCE_DIR}
-        ${CMAKE_BINARY_DIR})
+      COMMAND ${PYTHON_EXECUTABLE}
+              "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bbp-setup-pre-commit-config.py" --commit-checks=
+              --push-checks= ${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR})
   endif()
+  file(REMOVE ${PROJECT_BINARY_DIR}/git-push-message.cmake)
 endfunction(bbp_disable_precommit)
 
 function(bbp_enable_clang_formatting)
@@ -63,8 +79,9 @@ function(bbp_enable_clang_formatting)
   set(${CODING_CONV_PREFIX}_ClangFormat_DEPENDENCIES
       ""
       CACHE STRING "list of CMake targets to build before formatting C/C++ code")
-  mark_as_advanced(${CODING_CONV_PREFIX}_ClangFormat_OPTIONS ${CODING_CONV_PREFIX}_ClangFormat_FILES_RE
-                   ${CODING_CONV_PREFIX}_ClangFormat_EXCLUDES_RE)
+  mark_as_advanced(
+    ${CODING_CONV_PREFIX}_ClangFormat_OPTIONS ${CODING_CONV_PREFIX}_ClangFormat_FILES_RE
+    ${CODING_CONV_PREFIX}_ClangFormat_EXCLUDES_RE)
   execute_process(
     COMMAND git ls-files --error-unmatch .clang-format
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
@@ -128,8 +145,9 @@ function(bbp_enable_cmake_formatting)
   set(${CODING_CONV_PREFIX}_CMakeFormat_EXCLUDES_RE
       ".*/third[-_]parties/.*$$" ".*/third[-_]party/.*$$"
       CACHE STRING "list of regular expressions to exclude CMake files from formatting")
-  mark_as_advanced(${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS ${CODING_CONV_PREFIX}_CMakeFormat_FILES_RE
-                   ${CODING_CONV_PREFIX}_CMakeFormat_EXCLUDES_RE)
+  mark_as_advanced(
+    ${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS ${CODING_CONV_PREFIX}_CMakeFormat_FILES_RE
+    ${CODING_CONV_PREFIX}_CMakeFormat_EXCLUDES_RE)
   execute_process(
     COMMAND git ls-files --error-unmatch .cmake-format
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
@@ -244,15 +262,22 @@ bob_input(${CODING_CONV_PREFIX}_FORMATTING_ON "all" STRING
 bob_option(${CODING_CONV_PREFIX}_FORMATTING_CPP_CHANGES_ONLY
            "Only format the modified chunks, not the entire files" OFF)
 bob_option(${CODING_CONV_PREFIX}_TEST_FORMATTING "Add CTest formatting test" OFF)
-bob_option(${CODING_CONV_PREFIX}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting" ON)
-bob_option(${CODING_CONV_PREFIX}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted" OFF)
+bob_option(${CODING_CONV_PREFIX}_FORMATTING_NO_SUBMODULES "Exclude git submodules from formatting"
+           ON)
+bob_option(${CODING_CONV_PREFIX}_CLANG_FORMAT "Enable helper to keep C++ code properly formatted"
+           OFF)
 bob_option(${CODING_CONV_PREFIX}_CMAKE_FORMAT "Enable helper to keep CMake code properly formatted"
            OFF)
 
-bob_option(${CODING_CONV_PREFIX}_PRECOMMIT "Enable automatic checks before git commits" OFF)
-bob_option(${CODING_CONV_PREFIX}_PRECOMMIT_REGEN "Force precommit hook regeneration" OFF)
+bob_option(${CODING_CONV_PREFIX}_GIT_HOOKS
+           "Enable automatic checks when committing and pushing changes" OFF)
+bob_input(${CODING_CONV_PREFIX}_GIT_COMMIT_HOOKS "" STRING
+          "Comma-separated list of checks to perform when committing changes")
+bob_input(${CODING_CONV_PREFIX}_GIT_PUSH_HOOKS "courtesy-msg" STRING
+          "Comma-separated list of checks to perform when pushing changes")
 
-bob_option(${CODING_CONV_PREFIX}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
+bob_option(${CODING_CONV_PREFIX}_STATIC_ANALYSIS "Enable C++ static analysis during compilation"
+           OFF)
 bob_option(${CODING_CONV_PREFIX}_TEST_STATIC_ANALYSIS "Add CTest static analysis test" OFF)
 
 if(${CODING_CONV_PREFIX}_CLANG_FORMAT)
@@ -268,11 +293,11 @@ if(${CODING_CONV_PREFIX}_FORMATTING)
   bbp_enable_cmake_formatting()
 endif(${CODING_CONV_PREFIX}_FORMATTING)
 
-if(${CODING_CONV_PREFIX}_PRECOMMIT)
+if(${CODING_CONV_PREFIX}_GIT_HOOKS)
   bbp_enable_precommit()
-else(${CODING_CONV_PREFIX}_PRECOMMIT)
+else()
   bbp_disable_precommit()
-endif(${CODING_CONV_PREFIX}_PRECOMMIT)
+endif()
 
 if(${CODING_CONV_PREFIX}_STATIC_ANALYSIS)
   cmake_minimum_required(VERSION 3.6)

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -317,7 +317,7 @@ To enable these checks, use CMake variables `${PROJECT}_GIT_COMMIT_HOOKS` and
 each specific git operation. For instance:
 
 `cmake -Dfoo_GIT_COMMIT_HOOKS=clang-tidy \
-       -Dfood_GIT_PUSH_HOOKS=check-clang-format,courtesy-msg <path>`
+       -Dfoo_GIT_PUSH_HOOKS=check-clang-format,courtesy-msg <path>`
 
 This feature requires the `pre-commit` utility.
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -296,18 +296,30 @@ to modify it.
 Define `${PROJECT}_TEST_STATIC_ANALYSIS:BOOL` CMake variable to enforce formatting during
 the `test` make target.
 
-#### Pre-Commit
+#### Pre-Commit utility
 
-Enable CMake variable `${PROJECT}_PRECOMMIT` to enable automatic checks
-before git commits.
+Enable CMake option `${PROJECT}_GIT_HOOKS` to enable automatic checks
+before committing or pushing with git. the git operation will fail if
+one of the registered checks fails.
 
-For instance, given a project `foo`:
+The following checks are available:
+* `check-clang-format`: check C++ formatting
+* `check-cmake-format`: check CMake formatting
+* `clang-tidy`: execute static-analysis
+* `courtesy-msg`: print a courtesy message to the console.
+  This check never fails. The default message is a reminder to test and
+  format the changes when pushing a contribution with git.
+  A project can overwrite the message displayed by adding the CMake template
+  named `.git-push-message.cmake.in` at the root of the project directory.
 
-`cmake -Dfoo_PRECOMMIT:BOOL=ON <path>`
+To enable these checks, use CMake variables `${PROJECT}_GIT_COMMIT_HOOKS` and
+`${PROJECT}_GIT_PUSH_HOOKS` to specify which checks should be executeb for
+each specific git operation. For instance:
 
-if `${PROJECT}_FORMATTING` CMake variable is enabled, when performing a git
-commit, a succession of checks will be executed to ensure that your change
-complies with the coding conventions. It will be discarded otherwise.
+`cmake -Dfoo_GIT_COMMIT_HOOKS=clang-tidy \
+       -Dfood_GIT_PUSH_HOOKS=check-clang-format,courtesy-msg <path>`
+
+This feature requires the `pre-commit` utility.
 
 #### Bob
 

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -313,7 +313,7 @@ The following checks are available:
   named `.git-push-message.cmake.in` at the root of the project directory.
 
 To enable these checks, use CMake variables `${PROJECT}_GIT_COMMIT_HOOKS` and
-`${PROJECT}_GIT_PUSH_HOOKS` to specify which checks should be executeb for
+`${PROJECT}_GIT_PUSH_HOOKS` to specify which checks should be executed for
 each specific git operation. For instance:
 
 `cmake -Dfoo_GIT_COMMIT_HOOKS=clang-tidy \

--- a/cpp/cmake/bbp-setup-pre-commit-config.py
+++ b/cpp/cmake/bbp-setup-pre-commit-config.py
@@ -1,5 +1,10 @@
 import argparse
+from collections import namedtuple
+import copy
+import logging
+import os
 import os.path as osp
+import sys
 
 import yaml
 
@@ -8,115 +13,184 @@ try:
 except ImportError:
     from yaml import Loader
 
-from cpplib import str2bool
-
-
 HPC_PRE_COMMITS_REPO_URL = "https://github.com/BlueBrain/hpc-pre-commits"
 DEFAULT_HPC_PRE_COMMIT_REPO = dict(
     repo=HPC_PRE_COMMITS_REPO_URL, rev="master", hooks=[]
 )
-CHECK_CLANG_FORMAT_HOOK_ID = "check-clang-format"
-CHECK_CMAKE_FORMAT_HOOK_ID = "check-cmake-format"
-CHECK_CLANG_TIDY_HOOK_ID = "clang-tidy"
+
+
+class PreCommitConfig:
+    def __init__(self, file):
+        self._file = file
+        if osp.exists(file):
+            with open(file) as istr:
+                self._config = yaml.load(istr, Loader=Loader) or {}
+            self._previous_config = copy.deepcopy(self._config)
+        else:
+            self._config = {}
+            self._previous_config = {}
+        self._bbp_repo = self._initialize_bbp_repo()
+
+    def _initialize_bbp_repo(self):
+        repos = self.config.setdefault("repos", [])
+        for repo in repos:
+            if repo["repo"] == HPC_PRE_COMMITS_REPO_URL:
+                for k, v in DEFAULT_HPC_PRE_COMMIT_REPO.items():
+                    repo.setdefault(k, v)
+                return repo
+        bbp_repo = DEFAULT_HPC_PRE_COMMIT_REPO
+        repos.append(bbp_repo)
+        return bbp_repo
+
+    @property
+    def config(self):
+        return self._config
+
+    def enable_hook(self, new_hook):
+        logging.info(f"Enable hook {new_hook['name']}")
+        for hook in self._bbp_repo["hooks"]:
+            if (hook["id"], hook.get("name")) == (new_hook["id"], new_hook.get("name")):
+                hook.update(**new_hook)
+                break
+        else:
+            self._bbp_repo["hooks"].append(new_hook)
+
+    def enable_cmake_hook(self, name, stages, args, extra=None):
+        config = dict(
+            id="hpc-pc-cmake-build",
+            args=args,
+            name=name,
+            stages=stages,
+        )
+        if extra:
+            config.update(extra)
+        self.enable_hook(config)
+
+    def enable_cmake_target_hook(self, stages, build_dir, target, **kwargs):
+        self.enable_cmake_hook(
+            target, stages, ["--build", build_dir, "--target", target], **kwargs
+        )
+
+    def enable_cmake_script_hook(self, name, stages, file, **kwargs):
+        self.enable_cmake_hook(name, stages, ["-P", file], **kwargs)
+
+    def disable_cmake_hook(self, name):
+        for i, hook in enumerate(self._bbp_repo["hooks"]):
+            if (name, "hpc-pc-cmake-build") == (hook.get("name"), hook["id"]):
+                self._bbp_repo["hooks"].pop(i)
+                break
+
+    def save(self):
+        if self._previous_config != self.config:
+            logging.info("Updating pre-commit config file: %s", self._file)
+            with open(self._file, "w") as ostr:
+                yaml.dump(self.config, ostr, default_flow_style=False)
+        else:
+            logging.info("pre-commit config is up to date: %s", self._file)
+
+
+class CMakeTargetHook(namedtuple("CMakeTargetHook", ["build_dir", "target"])):
+    def enable(self, config, stages):
+        config.enable_cmake_target_hook(
+            stages, self.build_dir, self.target, extra=dict(always_run=True)
+        )
+
+    def disable(self, config):
+        config.disable_cmake_hook(self.target)
+
+    @property
+    def name(self):
+        return self.target
+
+
+class CMakeScriptHook(namedtuple("CMakeScriptHook", ["name", "file"])):
+    def enable(self, config, stages):
+        config.enable_cmake_script_hook(
+            self.name, stages, self.file, extra=dict(always_run=True, verbose=True)
+        )
+
+    def disable(self, config):
+        config.disable_cmake_hook(self.name)
 
 
 def _parse_cli(args=None):
     parser = argparse.ArgumentParser(description="Ensure CMake files formatting")
     parser.add_argument(
-        "--clang-format",
-        type=str2bool,
-        help="Enable C/C++ code formatting check",
-        const=True,
-        default=False,
-        nargs="?",
+        "--commit-checks",
+        help="Comma-separated list of checks to perform when committing changes",
+        default="",
     )
     parser.add_argument(
-        "-f",
-        "--force",
-        type=str2bool,
-        help="Force regenerating pre-commit hooks",
-        default=False,
-    )
-    parser.add_argument(
-        "--cmake-format", type=str2bool, help="Enable CMake files code formatting check"
-    )
-    parser.add_argument(
-        "--clang-tidy",
-        type=str2bool,
-        help="Enable static-analysis check with Clang Tidy",
+        "--push-checks",
+        help="Comma-separated list of checks to perform when pushing changes",
+        default="",
     )
     parser.add_argument("source_dir", help="CMake source directory")
     parser.add_argument("build_dir", help="CMake binary directory")
     return parser.parse_args(args=args)
 
 
-def get_or_set_bbp_pre_commit_repo(config):
-    repos = config.setdefault("repos", [])
-    for repo in repos:
-        if repo["repo"] == HPC_PRE_COMMITS_REPO_URL:
-            for k, v in DEFAULT_HPC_PRE_COMMIT_REPO.items():
-                repo.setdefault(k, v)
-            return repo
-    bbp_repo = DEFAULT_HPC_PRE_COMMIT_REPO
-    repos.append(bbp_repo)
-    return bbp_repo
-
-
-def enable_hook(repo, new_hook):
-    for hook in repo["hooks"]:
-        if (hook["id"], hook.get("name")) == (new_hook["id"], new_hook.get("name")):
-            hook.update(**new_hook)
-            break
-    else:
-        repo["hooks"].append(new_hook)
-
-
-def enable_cmake_hook(repo, build_dir, target):
-    enable_hook(
-        repo,
-        dict(
-            id="hpc-pc-cmake-build",
-            args=["--build", build_dir, "--target", target],
-            name=target,
-        ),
-    )
-
-
-def disable_cmake_hook(repo, hook_id):
-    for i, hook in enumerate(repo["hooks"]):
-        if (hook_id, "hpc-pc-cmake-build") == (hook.get("name"), hook["id"]):
-            repo["hooks"].pop(i)
-            break
+def fix_hook_file(hook):
+    if not osp.exists(hook):
+        return
+    with open(hook) as istr:
+        lines = istr.readlines()
+    shebang = f"#!/usr/bin/env {sys.executable}\n"
+    if lines[0] == "#!/usr/bin/env python\n":
+        logging.warning(f"Patching git hook script: {hook}")
+        lines[0] = shebang
+        with open(hook, "w") as ostr:
+            ostr.writelines(lines)
 
 
 def main(**kwargs):
     args = _parse_cli(**kwargs)
     PRE_COMMIT_CONFIG = osp.join(args.source_dir, ".pre-commit-config.yaml")
-    if osp.exists(PRE_COMMIT_CONFIG):
-        if not args.force:
-            return
-        else:
-            with open(PRE_COMMIT_CONFIG) as istr:
-                config = yaml.load(istr, Loader=Loader) or {}
-    else:
-        config = {}
+    ALL_HOOKS = [
+        CMakeTargetHook(args.build_dir, "check-clang-format"),
+        CMakeTargetHook(args.build_dir, "check-cmake-format"),
+        CMakeTargetHook(args.build_dir, "clang-tidy"),
+        CMakeScriptHook(
+            "courtesy-msg", osp.join(args.build_dir, "git-push-message.cmake")
+        ),
+    ]
 
-    repo = get_or_set_bbp_pre_commit_repo(config)
-    if args.clang_format:
-        enable_cmake_hook(repo, args.build_dir, CHECK_CLANG_FORMAT_HOOK_ID)
-    else:
-        disable_cmake_hook(repo, CHECK_CLANG_FORMAT_HOOK_ID)
-    if args.cmake_format:
-        enable_cmake_hook(repo, args.build_dir, CHECK_CMAKE_FORMAT_HOOK_ID)
-    else:
-        disable_cmake_hook(repo, CHECK_CMAKE_FORMAT_HOOK_ID)
-    if args.clang_tidy:
-        enable_cmake_hook(repo, args.build_dir, CHECK_CLANG_TIDY_HOOK_ID)
-    else:
-        disable_cmake_hook(repo, CHECK_CLANG_TIDY_HOOK_ID)
-    with open(PRE_COMMIT_CONFIG, "w") as ostr:
-        yaml.dump(config, ostr, default_flow_style=False)
+    config = PreCommitConfig(PRE_COMMIT_CONFIG)
+
+    hooks = dict((hook.name, hook) for hook in ALL_HOOKS)
+    assert len(hooks) == len(ALL_HOOKS), "hooks must have unique names"
+
+    # Build a dictionary from the two CLI arguments
+    # For example: {"clang-tidy": ["commit"], "courtesy-msg": ["commit", "push"]}
+    hook_stages = {}
+    for names, stage in [(args.commit_checks, "commit"), (args.push_checks, "push")]:
+        for name in names.split(","):
+            name = name.strip()
+            if name:
+                hook_stages.setdefault(name, []).append(stage)
+
+    # Enable hooks mentioned in `hook_stages`
+    for name, stages in hook_stages.items():
+        hook = hooks.pop(name, None)
+        if hook is None:
+            logging.warning(
+                f"Unknown check named: '{name}', "
+                f"available checks: {', '.join(hooks.keys())}"
+            )
+            continue
+        hook.enable(config, stages)
+
+    # Disable the other ones
+    for hook in hooks.values():
+        hook.disable(config)
+
+    config.save()
+
+    fix_hook_file(osp.join(args.source_dir, ".git", "hooks", "pre-commit"))
+    fix_hook_file(osp.join(args.source_dir, ".git", "hooks", "pre-push"))
 
 
 if __name__ == "__main__":
+    level = logging.INFO if "VERBOSE" in os.environ else logging.WARN
+    logging.basicConfig(level=level, format="%(message)s")
     main()

--- a/cpp/cmake/bbp-setup-pre-commit-config.py
+++ b/cpp/cmake/bbp-setup-pre-commit-config.py
@@ -64,7 +64,7 @@ class PreCommitConfig:
         )
         if extra:
             config.update(extra)
-        self.enable_hook(config)
+        self._enable_hook(config)
 
     def enable_cmake_target_hook(self, stages, build_dir, target, **kwargs):
         self.enable_cmake_hook(

--- a/cpp/cmake/bbp-setup-pre-commit-config.py
+++ b/cpp/cmake/bbp-setup-pre-commit-config.py
@@ -46,7 +46,7 @@ class PreCommitConfig:
     def config(self):
         return self._config
 
-    def enable_hook(self, new_hook):
+    def _enable_hook(self, new_hook):
         logging.info(f"Enable hook {new_hook['name']}")
         for hook in self._bbp_repo["hooks"]:
             if (hook["id"], hook.get("name")) == (new_hook["id"], new_hook.get("name")):

--- a/cpp/cmake/git-push-message.cmake.in
+++ b/cpp/cmake/git-push-message.cmake.in
@@ -6,7 +6,8 @@
 # in ${PROJECT_SOURCE_DIR}/.git-push-message.cmake.in
 
 message(STATUS "\n\
-This is a courtesy message to remind you to properly test and format your changes.\n\
+This is a courtesy message to remind you to properly test and format your changes\n\
+before opening a Pull Request.\n\
 To format your changes:\n\
   pushd /path/to/build/dir\n\
   cmake -D@CODING_CONV_PREFIX@_FORMATTING=ON -D@CODING_CONV_PREFIX@_TEST_FORMATTING=ON .\n\

--- a/cpp/cmake/git-push-message.cmake.in
+++ b/cpp/cmake/git-push-message.cmake.in
@@ -1,0 +1,16 @@
+# This file is the template of a CMake script executed by the pre-commit utility
+# whenever the hook named `courtesy-msg` is enabled
+# (see "Pre-commit utility" section in cpp/README.md)
+#
+# To execute your own script (with another message for instance), write a CMake template
+# in ${PROJECT_SOURCE_DIR}/.git-push-message.cmake.in
+
+message(STATUS "\n\
+This is a courtesy message to remind you to properly test and format your changes.\n\
+To format your changes:\n\
+  pushd /path/to/build/dir\n\
+  cmake -D@CODING_CONV_PREFIX@_FORMATTING=ON -D@CODING_CONV_PREFIX@_TEST_FORMATTING=ON .\n\
+  make clang_format cmake_format\n\
+To run the tests and check the formatting:\n\
+  make test\n\
+You should also read the contributing guidelines this project may provide")


### PR DESCRIPTION
* Refactor the CMake options as well as the Python script used to
  generate the pre-commit configuration file to support the
  ability to launch tasks before pushing code.
  For instance, it is now possible to run clang-format
  and/or cmake-format when doing `git push` instead of
  at each commit like before.
* Introduce a new kind of hook to write a courtesy message
  to the console.
* patch scripts generated by pre-commit in .git/hooks to fix the shebang
  which can lead to crashes when working in a `spack build-env` environment

Please read the updated documentation in `cpp/README.md` for more information.

Fixes #81