### PR TITLE
Improve clang-format version parsing

### DIFF
--- a/cpp/cmake/FindClangFormat.cmake
+++ b/cpp/cmake/FindClangFormat.cmake
@@ -34,7 +34,7 @@ else()
                NAMES clang-format
                      clang-format-11
                      clang-format-10
-                     clang-format-8
+                     clang-format-9
                      clang-format-8
                      clang-format-7
                      clang-format-6.0

--- a/cpp/cmake/FindClangFormat.cmake
+++ b/cpp/cmake/FindClangFormat.cmake
@@ -58,9 +58,8 @@ if(ClangFormat_EXECUTABLE)
                   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
   if(ClangFormat_version MATCHES ".*clang-format version .*")
-    # ClangFormat_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1""
+    # ClangFormat_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1"
     # ClangFormat_version sample: "Ubuntu clang-format version 11.0.0-2~ubuntu20.04.1"
-    # (tags/RELEASE_391/rc2)"
     string(REGEX
            REPLACE ".*clang-format version ([.0-9]+).*"
                    "\\1"

--- a/cpp/cmake/FindClangFormat.cmake
+++ b/cpp/cmake/FindClangFormat.cmake
@@ -32,7 +32,9 @@ if(ClangFormat_FIND_VERSION AND ClangFormat_FIND_VERSION_EXACT)
 else()
   find_program(ClangFormat_EXECUTABLE
                NAMES clang-format
-                     clang-format-9
+                     clang-format-11
+                     clang-format-10
+                     clang-format-8
                      clang-format-8
                      clang-format-7
                      clang-format-6.0
@@ -55,11 +57,12 @@ if(ClangFormat_EXECUTABLE)
                   OUTPUT_VARIABLE ClangFormat_version
                   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-  if(ClangFormat_version MATCHES "^clang-format version .*")
-    # ClangFormat_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1
+  if(ClangFormat_version MATCHES ".*clang-format version .*")
+    # ClangFormat_version sample: "clang-format version 3.9.1-4ubuntu3~16.04.1""
+    # ClangFormat_version sample: "Ubuntu clang-format version 11.0.0-2~ubuntu20.04.1"
     # (tags/RELEASE_391/rc2)"
     string(REGEX
-           REPLACE "clang-format version ([.0-9]+).*"
+           REPLACE ".*clang-format version ([.0-9]+).*"
                    "\\1"
                    ClangFormat_VERSION
                    "${ClangFormat_version}")


### PR DESCRIPTION
  - On newer ubunut, clang-format print version with platform
    name at the begining : Ubuntu clang-format version 11.0.0-2~ubuntu20.04.1
  - Add clang-format binary names for v10 and v11

fixes #86