### PR TITLE
Do not require a strict version for cmake-format

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -118,7 +118,7 @@ endfunction(bbp_enable_clang_formatting)
 
 function(bbp_enable_cmake_formatting)
   find_package(PythonInterp 3.5 REQUIRED)
-  find_package(CMakeFormat 0.6.0 EXACT REQUIRED)
+  find_package(CMakeFormat 0.6 REQUIRED)
   set(${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS
       ""
       CACHE STRING "cmake-format options")

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -119,7 +119,7 @@ endfunction(bbp_enable_clang_formatting)
 function(bbp_enable_cmake_formatting)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(CMakeFormat 0.6 REQUIRED)
-  if(CMakeFormat_FOUND AND CMakeFormat_VERSION VERSION_GREATER_EQUAL 0.6)
+  if(CMakeFormat_FOUND AND CMakeFormat_VERSION VERSION_GREATER_EQUAL 0.7)
     message(SEND_ERROR "Unsupported cmake-format version.\
     Expects 0.6 <= version < 0.7 but found version ${CMakeFormat_VERSION}")
   endif()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -119,6 +119,11 @@ endfunction(bbp_enable_clang_formatting)
 function(bbp_enable_cmake_formatting)
   find_package(PythonInterp 3.5 REQUIRED)
   find_package(CMakeFormat 0.6 REQUIRED)
+  if(CMakeFormat_FOUND AND CMakeFormat_VERSION VERSION_GREATER_EQUAL 0.6)
+    message(SEND_ERROR "Unsupported cmake-format version.\
+    Expects 0.6 <= version < 0.7 but found version ${CMakeFormat_VERSION}")
+  endif()
+
   set(${CODING_CONV_PREFIX}_CMakeFormat_OPTIONS
       ""
       CACHE STRING "cmake-format options")
@@ -255,18 +260,13 @@ bob_option(${CODING_CONV_PREFIX}_PRECOMMIT_REGEN "Force precommit hook regenerat
 bob_option(${CODING_CONV_PREFIX}_STATIC_ANALYSIS "Enable C++ static analysis during compilation" OFF)
 bob_option(${CODING_CONV_PREFIX}_TEST_STATIC_ANALYSIS "Add CTest static analysis test" OFF)
 
-if(${CODING_CONV_PREFIX}_CLANG_FORMAT)
+if(${CODING_CONV_PREFIX}_CLANG_FORMAT OR ${CODING_CONV_PREFIX}_FORMATTING)
   bbp_enable_clang_formatting()
-endif(${CODING_CONV_PREFIX}_CLANG_FORMAT)
+endif()
 
-if(${CODING_CONV_PREFIX}_CMAKE_FORMAT)
+if(${CODING_CONV_PREFIX}_CMAKE_FORMAT OR ${CODING_CONV_PREFIX}_FORMATTING)
   bbp_enable_cmake_formatting()
-endif(${CODING_CONV_PREFIX}_CMAKE_FORMAT)
-
-if(${CODING_CONV_PREFIX}_FORMATTING)
-  bbp_enable_clang_formatting()
-  bbp_enable_cmake_formatting()
-endif(${CODING_CONV_PREFIX}_FORMATTING)
+endif()
 
 if(${CODING_CONV_PREFIX}_PRECOMMIT)
   bbp_enable_precommit()

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -49,7 +49,7 @@ This CMake project expects for the following utilities to be available:
 * [Python 3.5 or higher](https://python.org)
 * [ClangFormat 9](https://releases.llvm.org/9.0.0/tools/clang/docs/ClangFormat.html)
 * [ClangTidy 7](https://releases.llvm.org/7.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html)
-* [cmake-format](https://github.com/cheshirekow/cmake_format) Python package
+* [cmake-format](https://github.com/cheshirekow/cmake_format) Python package version 0.6
 * [pre-commit](https://pre-commit.com/) Python package
 
 Optionally, it will also look for:


### PR DESCRIPTION
Since last deployment with spack, cmake-format 0.6.10 is provided which raises an issue because there is a strict requirement on cmake-format 0.6.10.

I do not have enough time to test more recent version of CMakeFormat so let's restrict to >=0.6 and <0.7