### PR TITLE
Add new helper, cpp_cc_git_submodule QUIET flag.

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ if(NOT CODING_CONV_PREFIX)
 endif(NOT CODING_CONV_PREFIX)
 include(cmake/bob.cmake)
 include(cmake/3rdparty.cmake)
+include(cmake/build-time-copy.cmake)
 
 function(cpp_cc_enable_precommit)
   find_package(PythonInterp 3.5 REQUIRED)

--- a/cpp/cmake/3rdparty.cmake
+++ b/cpp/cmake/3rdparty.cmake
@@ -47,6 +47,7 @@ endfunction()
 #
 # cpp_cc_git_submodule(source_dir
 #                      [DISABLED]
+#                      [QUIET]
 #                      SUBDIR path
 #                      [BUILD] [<arguments>]
 #                      [PACKAGE] [<arguments>]
@@ -63,6 +64,8 @@ endfunction()
 #
 # If the DISABLED argument is provided, then the default value for the CMake
 # option is OFF.
+#
+# If the QUIET argument is provided then no status message will be printed.
 #
 # If the BUILD argument is provided then the directory is added to the build
 # through the add_subdirectory CMake function. Arguments following the BUILD
@@ -81,7 +84,7 @@ endfunction()
 # If the GIT_ARGS argument is provided, then its value supersedes the default options.
 #
 function(cpp_cc_git_submodule name)
-  cmake_parse_arguments(PARSE_ARGV 1 opt "DISABLED" "SUBDIR" "PACKAGE;BUILD;GIT_ARGS")
+  cmake_parse_arguments(PARSE_ARGV 1 opt "DISABLED;QUIET" "SUBDIR" "PACKAGE;BUILD;GIT_ARGS")
   string(MAKE_C_IDENTIFIER "USE_${name}" option_suffix)
   string(TOUPPER "3RDPARTY_${option_suffix}" option_suffix)
   if(opt_DISABLED)
@@ -113,7 +116,9 @@ function(cpp_cc_git_submodule name)
       cpp_cc_init_git_submodule("${submodule_path}")
     endif()
   endif()
-  message(STATUS "3rdparty project: using ${name} from \"${submodule_path}\"")
+  if(NOT opt_QUIET)
+    message(STATUS "3rd party project: using ${name} from \"${submodule_path}\"")
+  endif()
   if(opt_BUILD)
       add_subdirectory(${submodule_path} ${opt_BUILD})
   elseif("BUILD" IN_LIST opt_KEYWORDS_MISSING_VALUES)

--- a/cpp/cmake/build-time-copy.cmake
+++ b/cpp/cmake/build-time-copy.cmake
@@ -1,0 +1,30 @@
+# Create a build rule that copies a file.
+#
+# cpp_cc_build_time_copy(INPUT <input_path>
+#                        OUTPUT <output_path>)
+#
+# This creates a custom target that is always built and depends on
+# `output_path` and a rule to create `output_path` by copying `input_path`.
+# This means that changes to the input file (`input_path`, presumably in the
+# source tree) can be propagated to `output_path` (presumably in the build
+# tree) automatically and without re-running CMake. The existence of a custom
+# command that produces `output_path` makes it trivial for other targets to
+# declare that they depend on this file.
+function(cpp_cc_build_time_copy)
+  cmake_parse_arguments(opt "" "INPUT;OUTPUT" "" ${ARGN})
+  if(NOT DEFINED opt_INPUT)
+    message(ERROR "build_time_copy missing required keyword argument INPUT.")
+  endif()
+  if(NOT DEFINED opt_OUTPUT)
+    message(ERROR "build_time_copy missing required keyword argument OUTPUT.")
+  endif()
+  string(SHA256 target_name "${opt_INPUT};${opt_OUTPUT}")
+  set(target_name "build-time-copy-${target_name}")
+  if(NOT TARGET "${target_name}")
+    add_custom_command(
+      OUTPUT "${opt_OUTPUT}"
+      DEPENDS "${opt_INPUT}"
+      COMMAND ${CMAKE_COMMAND} -E copy "${opt_INPUT}" "${opt_OUTPUT}")
+    add_custom_target(${target_name} ALL DEPENDS "${opt_OUTPUT}")
+  endif()
+endfunction()


### PR DESCRIPTION
- Add `cpp_cc_build_time_copy` helper function that sets up a rule to copy a file from the source to the build tree at build time.
- Add an optional `QUIET` option to the existing `cpp_cc_git_submodule` helper function to suppress status output.

Both are intended for use in [Core]NEURON.