### PR TITLE
Add NO_TARGET option to build time copy helper.

### DIFF
--- a/cpp/cmake/build-time-copy.cmake
+++ b/cpp/cmake/build-time-copy.cmake
@@ -1,7 +1,8 @@
 # Create a build rule that copies a file.
 #
 # cpp_cc_build_time_copy(INPUT <input_path>
-#                        OUTPUT <output_path>)
+#                        OUTPUT <output_path>
+#                        [NO_TARGET])
 #
 # This creates a custom target that is always built and depends on
 # `output_path` and a rule to create `output_path` by copying `input_path`.
@@ -9,22 +10,30 @@
 # source tree) can be propagated to `output_path` (presumably in the build
 # tree) automatically and without re-running CMake. The existence of a custom
 # command that produces `output_path` makes it trivial for other targets to
-# declare that they depend on this file.
+# declare that they depend on this file, provided that they are working in the
+# same directory (CMakeLists.txt -- see documentation of DEPENDS arguments to
+# add_custom_command and add_custom_target). If the NO_TARGET flag is passed
+# then no target is added, and the caller takes responsibility for declaring a
+# dependency on the output file and causing it to be built. This can be a good
+# idea to avoid the number of top level targets growing too large, which causes
+# the Make build system to be very slow.
 function(cpp_cc_build_time_copy)
-  cmake_parse_arguments(opt "" "INPUT;OUTPUT" "" ${ARGN})
+  cmake_parse_arguments(opt "NO_TARGET" "INPUT;OUTPUT" "" ${ARGN})
   if(NOT DEFINED opt_INPUT)
     message(ERROR "build_time_copy missing required keyword argument INPUT.")
   endif()
   if(NOT DEFINED opt_OUTPUT)
     message(ERROR "build_time_copy missing required keyword argument OUTPUT.")
   endif()
-  string(SHA256 target_name "${opt_INPUT};${opt_OUTPUT}")
-  set(target_name "build-time-copy-${target_name}")
-  if(NOT TARGET "${target_name}")
-    add_custom_command(
-      OUTPUT "${opt_OUTPUT}"
-      DEPENDS "${opt_INPUT}"
-      COMMAND ${CMAKE_COMMAND} -E copy "${opt_INPUT}" "${opt_OUTPUT}")
-    add_custom_target(${target_name} ALL DEPENDS "${opt_OUTPUT}")
+  add_custom_command(
+    OUTPUT "${opt_OUTPUT}"
+    DEPENDS "${opt_INPUT}"
+    COMMAND ${CMAKE_COMMAND} -E copy "${opt_INPUT}" "${opt_OUTPUT}")
+  if(NOT opt_NO_TARGET)
+    string(SHA256 target_name "${opt_INPUT};${opt_OUTPUT}")
+    set(target_name "build-time-copy-${target_name}")
+    if(NOT TARGET "${target_name}")
+      add_custom_target(${target_name} ALL DEPENDS "${opt_OUTPUT}")
+    endif()
   endif()
 endfunction()


### PR DESCRIPTION
By default `cpp_cc_build_time_copy` (recently added in https://github.com/BlueBrain/hpc-coding-conventions/pull/95) creates a target that is always built that depends on the output file, ensuring that it is already up to date. This potentially generates a large number of top-level always-built targets, which can be rather slow when using legacy make/Makefiles. The Ninja build system does not seem to have the same problem.

This commit adds an optional `NO_TARGET` flag, which sets up the rule to copy the file but does not create a top-level always-built target. This means that the caller can create a single such target depending on many files, which is much more efficient when using make/Makefiles.

For example this:
```cmake
cpp_cc_build_time_copy(INPUT "{source}/file1.txt" OUTPUT "{build}/file1.txt")
cpp_cc_build_time_copy(INPUT "{source}/file2.txt" OUTPUT "{build}/file2.txt")
```
creates two top-level rules while
```cmake
cpp_cc_build_time_copy(INPUT "{source}/file1.txt" OUTPUT "{build}/file1.txt" NO_TARGET)
cpp_cc_build_time_copy(INPUT "{source}/file2.txt" OUTPUT "{build}/file2.txt" NO_TARGET)
add_custom_target(copy-files ALL DEPENDS "{build}/file1.txt" "{build}/file2.txt")
```
creates just one. When large numbers of files are being copied then this difference can be significant.

Note that if `NO_TARGET` is passed **and** no dependency is declared on the `OUTPUT` file in the same `CMakeLists.txt` the file will not be copied. See, for example, https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#how-can-i-add-a-dependency-to-a-source-file-which-is-generated-in-a-subdirectory and https://cmake.org/cmake/help/latest/command/add_custom_command.html.