### PR TITLE
Add LGPL license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+*********************************************************************************
+*  BlueBrain C++ Coding Conventions
+*
+*  Copyright (c) 2019, 2020, 2021 Blue Brain Project, EPFL.
+*
+* BlueBrain C++ Coding Conventions are licensed under the LGPL,
+* unless noted otherwise, e.g., for external dependencies.
+* See file LGPL.txt for the full license. Examples and external
+* dependencies are either LGPL or BSD-licensed.
+*
+* THE SOFTWARE IS PROVIDED _AS IS_, WITHOUT WARRANTY OF ANY KIND, EXPRESS
+* OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+* THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+* DEALINGS IN THE SOFTWARE.
+*
+*********************************************************************************/


### PR DESCRIPTION
This change provides a LICENSE file dictating that this project is released under the LGPL license, like all BlueBrain open-source components.