### PR TITLE
Run compile commands from the build directory.

### DIFF
--- a/cpp/cmake/bbp-clang-format.py
+++ b/cpp/cmake/bbp-clang-format.py
@@ -245,7 +245,7 @@ def main(**kwargs):
             succeeded = action(GitDiffDelta.from_applies_on(args.applies_on), args)
         else:
             for cpp_file in filter_files_outside_time_range(
-                args, collect_files(args.compile_commands_file, filter_cpp_file)
+                args, collect_files(args, filter_cpp_file)
             ):
                 succeeded &= action(cpp_file, args.executable, args.options)
     return succeeded

--- a/cpp/cmake/bbp-clang-tidy.py
+++ b/cpp/cmake/bbp-clang-tidy.py
@@ -38,7 +38,7 @@ def main(**kwargs):
     )
     succeeded = True
     for ok in workers.imap_unordered(
-        action, collect_files(args.compile_commands_file, filter_cpp_file)
+        action, collect_files(args, filter_cpp_file)
     ):
         succeeded &= ok
     workers.close()


### PR DESCRIPTION
As reported in https://github.com/BlueBrain/CoreNeuron/issues/548, `make clang-format` works but `ninja clang-format` does not.

This seems to be because the formatting script invokes the compiler to figure out which headers are included (it's not immediately clear to me why this is necessary), and with Ninja the include paths are not specified absolutely so it is necessary to run from the build directory.

This patch makes sure the compiler is run from the build directory.