### PR TITLE
Fix clang-format with Ninja.

### DIFF
--- a/cpp/cmake/cpplib.py
+++ b/cpp/cmake/cpplib.py
@@ -140,6 +140,11 @@ def collect_included_headers(cli_args, entry, filter_cpp_file):
         if line[-1] == "\\":
             line = line[:-1]
         for header in line.split():
+            # We run the compiler in `binary_dir`, so relative paths should be
+            # interpreted relative to there.
+            if not osp.isabs(header):
+                header = osp.join(cli_args.binary_dir, header)
+            header = osp.abspath(header)
             if not filter_cpp_file(header):
                 yield header
 


### PR DESCRIPTION
https://github.com/BlueBrain/hpc-coding-conventions/pull/101 made sure that when the compiler is run to find header dependencies then the correct working directory was used, but it did not account for the compiler returning relative paths in this case.

The relative paths were being discarded later, with the result that `ninja clang-format` would silently not format header files.