### PR TITLE
Tweaks to clang-format target.

### DIFF
--- a/cpp/cmake/FindClangFormat.cmake
+++ b/cpp/cmake/FindClangFormat.cmake
@@ -103,8 +103,10 @@ if(ClangFormat_EXECUTABLE)
       set(ClangFormat_VERSION_PATCH 0)
     endif()
 
+    get_filename_component(ClangFormat_DIRECTORY "${ClangFormat_EXECUTABLE}" DIRECTORY)
     find_program(ClangFormatDiff_EXECUTABLE
-                 NAMES clang-format-diff-${ClangFormat_VERSION_MAJOR} clang-format-diff
+                 NAMES clang-format-diff-${ClangFormat_VERSION_MAJOR} clang-format-diff clang-format-diff.py
+                 PATHS "${ClangFormat_DIRECTORY}/../share/clang"
                  DOC "clang-format-diff executable")
     mark_as_advanced(ClangFormatDiff_EXECUTABLE)
   endif()

--- a/cpp/cmake/bbp-clang-format.py
+++ b/cpp/cmake/bbp-clang-format.py
@@ -38,11 +38,13 @@ def file_filters_cli_options(args):
     result = ["-S", args.source_dir, "-B", args.binary_dir]
     if args.git_modules:
         result.append('--git-modules')
+    # --files-re A --files-re B would be parsed as [B], not [A, B]
+    # --files-re A B will be parsed [correctly] as [A, B]
     for re_opt, patterns in [
         ("--files-re", args.files_re),
         ("--excludes-re", args.excludes_re),
     ]:
-        result += list(itertools.chain(*list(itertools.product([re_opt], patterns))))
+        result += [re_opt] + patterns
     return result
 
 

--- a/cpp/cmake/bbp-diff-filter.py
+++ b/cpp/cmake/bbp-diff-filter.py
@@ -36,7 +36,7 @@ def main(**kwargs):
             for pattern in DIFF_HEADER_PATTERNS:
                 match = pattern.match(line)
                 if match:
-                    filename = match.group(0)
+                    filename = match.group(1)
                     break
             if filename:
                 file = osp.realpath(osp.join(args.source_dir, filename))


### PR DESCRIPTION
I tried to build NEURON using
```
    -DNRN_CLANG_FORMAT=ON \
    -DNRN_CMAKE_FORMAT=ON \
    -DNEURON_CMAKE_FORMAT=ON \
    -DNRN_FORMATTING_ON="since-ref:origin/master" \
    -DNRN_FORMATTING_CPP_CHANGES_ONLY=ON
```
and encountered several issues. This fixes the ones I noticed:
- When `${CODING_CONV_PREFIX}_ClangFormat_FILES_RE` contains multiple entries, only one of them was being used.
- `clang-format-diff.py` was not found on BB5.
- `cpp/cmake/bbp-clang-format.py` did not parse filenames from diffs correctly.