### PR TITLE
Fix saving of .pre-commit-config.yaml

### DIFF
--- a/cpp/cmake/bbp-setup-pre-commit-config.py
+++ b/cpp/cmake/bbp-setup-pre-commit-config.py
@@ -25,11 +25,10 @@ class PreCommitConfig:
         if osp.exists(file):
             with open(file) as istr:
                 self._config = yaml.load(istr, Loader=Loader) or {}
-            self._previous_config = copy.deepcopy(self._config)
         else:
             self._config = {}
-            self._previous_config = {}
         self._bbp_repo = self._initialize_bbp_repo()
+        self._previous_config = copy.deepcopy(self._config)
 
     def _initialize_bbp_repo(self):
         repos = self.config.setdefault("repos", [])


### PR DESCRIPTION
The file is not modified anymore when `${CODING_CONV_PREFIX}_GIT_HOOKS` is kept OFF.
Fixes #113