### PR TITLE
collect_files: CWD to source_dir because calling git

### DIFF
--- a/cpp/cmake/cpplib.py
+++ b/cpp/cmake/cpplib.py
@@ -34,12 +34,12 @@ def collect_files(source_dir, filter_file):
         filter_file: a function returning `True` if the given file should be
         excluded, `False` otherwise.
     Returns:
-        Generator of C++ files
+        Generator of path to files in source_dir
     """
 
-    cmd = ["git", "ls-tree", "-r", "-z", "--name-only", "--full-name", "HEAD", source_dir]
+    cmd = ["git", "ls-tree", "-r", "-z", "--name-only", "--full-name", "HEAD"]
     log_command(cmd)
-    files = subprocess.check_output(cmd).decode('utf-8').split('\0')
+    files = subprocess.check_output(cmd, cwd=source_dir).decode('utf-8').split('\0')
     files = [x for x in files if not filter_file(x)]
     files = [os.path.join(source_dir, x) for x in files]
     return files


### PR DESCRIPTION
This change handles the case where `CMAKE_SOURCE_DIR` is not a parent directory of `CMAKE_BINARY_DIR`, which can lead to the following error because git is not able to find the .git directory when climbing back up from `CMAKE_BINARY_DIR`:

```
10/363 Test   #1: CMakeFormat ............................................................................***Failed    0.41 sec
fatal: Not a git repository (or any parent up to mount point /gpfs/bbp.cscs.ch/ssd)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
Traceback (most recent call last):
  File "/gpfs/bbp.cscs.ch/ssd/gitlab_map_jobs/bbpcihpcproj12/P466[85](https://bbpgitlab.epfl.ch/hpc/HBP_STEPS/-/jobs/203111#L85)/J203108/spack-build/spack-stage-steps-develop-4r7utlegtpec5hktzmbr5pkc6hht4tgu/spack-src/CMake/hpc-coding-conventions/cpp/cmake/bbp-cmake-format.py", line 99, in <module>
    sys.exit(0 if main() else 1)
  File "/gpfs/bbp.cscs.ch/ssd/gitlab_map_jobs/bbpcihpcproj12/P46685/J203108/spack-build/spack-stage-steps-develop-4r7utlegtpec5hktzmbr5pkc6hht4tgu/spack-src/CMake/hpc-coding-conventions/cpp/cmake/bbp-cmake-format.py", line 91, in main
    for cmake_file in collect_files(args.source_dir, make_file_filter(excludes_re, files_re)):
  File "/gpfs/bbp.cscs.ch/ssd/gitlab_map_jobs/bbpcihpcproj12/P46685/J203108/spack-build/spack-stage-steps-develop-4r7utlegtpec5hktzmbr5pkc6hht4tgu/spack-src/CMake/hpc-coding-conventions/cpp/cmake/cpplib.py", line 42, in collect_files
    files = subprocess.check_output(cmd).decode('utf-8').split('\0')
  File "/gpfs/bbp.cscs.ch/ssd/apps/bsd/2022-01-10/stage_externals/install_gcc-11.2.0-skylake/python-3.9.7-yj5alh/lib/python3.9/subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/gpfs/bbp.cscs.ch/ssd/apps/bsd/2022-01-10/stage_externals/install_gcc-11.2.0-skylake/python-3.9.7-yj5alh/lib/python3.9/subprocess.py", line 528, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['git', 'ls-tree', '-r', '-z', '--name-only', '--full-name', 'HEAD', '/gpfs/bbp.cscs.ch/ssd/gitlab_map_jobs/bbpcihpcproj12/P46685/J203108/spack-build/spack-stage-steps-develop-4r7utlegtpec5hktzmbr5pkc6hht4tgu/spack-src']' returned non-zero exit status 128.
```