### PR TITLE
Assume default executables.

### DIFF
--- a/cpp/cmake/bbp-clang-format.py
+++ b/cpp/cmake/bbp-clang-format.py
@@ -67,6 +67,11 @@ def build_action_func(action_name):
 
 def main(**kwargs):
     args = parse_cli(**kwargs)
+
+    if not args.executable:
+        args.executable = "clang-format"
+
+
     excludes_re = [re.compile(r) for r in args.excludes_re]
     files_re = [re.compile(r) for r in args.files_re]
     filter_cpp_file = make_file_filter(excludes_re, files_re)

--- a/cpp/cmake/bbp-clang-format.py
+++ b/cpp/cmake/bbp-clang-format.py
@@ -71,7 +71,6 @@ def main(**kwargs):
     if not args.executable:
         args.executable = "clang-format"
 
-
     excludes_re = [re.compile(r) for r in args.excludes_re]
     files_re = [re.compile(r) for r in args.files_re]
     filter_cpp_file = make_file_filter(excludes_re, files_re)

--- a/cpp/cmake/bbp-clang-tidy.py
+++ b/cpp/cmake/bbp-clang-tidy.py
@@ -29,6 +29,8 @@ def main(**kwargs):
         ("-p", dict(dest="compile_commands_file", type=str))
     ]
     args = parse_cli(parser_args=parser_args, choices=["check"], **kwargs)
+    args.executable = "clang-tidy" if not args.executable else args.executable
+
     excludes_re = [re.compile(r) for r in args.excludes_re]
     files_re = [re.compile(r) for r in args.files_re]
     filter_cpp_file = make_file_filter(excludes_re, files_re)

--- a/cpp/cmake/bbp-cmake-format.py
+++ b/cpp/cmake/bbp-cmake-format.py
@@ -84,6 +84,10 @@ def build_action_func(args):
 
 def main(**kwargs):
     args = parse_cli(**kwargs)
+
+    if not args.executable:
+        args.executable = "cmake-format"
+
     excludes_re = [re.compile(r) for r in args.excludes_re]
     files_re = [re.compile(r) for r in args.files_re]
     with build_action_func(args) as action:


### PR DESCRIPTION
Inside `bbp-clang-format.py`, if nothing was set through `--executable`, use `clang-format`.