### PR TITLE
Improve C++ snippets generation / add CI

### DIFF
--- a/.ci/check_code_formatting.sh
+++ b/.ci/check_code_formatting.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VENV=build/venv-code-formatting
+CLANG_FORMAT_VERSION=13.0.0
+
+if [[ ! -d $VENV ]]; then
+    python3 -mvenv "$VENV"
+    "$VENV/bin/pip" install               \
+      clang-format==$CLANG_FORMAT_VERSION \
+      jinja2                              \
+      pyyaml 
+fi
+
+set +u  # ignore errors in virtualenv's activate
+source "$VENV/bin/activate"
+set -u
+
+cd cpp/formatting
+make distclean all
+if ! git diff --exit-code README.md ;then
+    cat >&2 <<EOF
+
+Error: README.md has changed! 💥 💔 💥
+Please rebuild it and commit its changes with commands:
+
+  .ci/check_code_formatting.sh
+  git add cpp/formatting/README.md
+  git commit
+EOF
+    exit 1
+fi

--- a/.ci/check_python_flake8.sh
+++ b/.ci/check_python_flake8.sh
@@ -14,4 +14,4 @@ set +u  # ignore errors in virtualenv's activate
 source "$VENV/bin/activate"
 set -u
 
-flake8 cpp/cmake dev/bump
+flake8 cpp/cmake dev/bump cpp/formatting

--- a/.ci/check_python_format.sh
+++ b/.ci/check_python_format.sh
@@ -14,5 +14,5 @@ set +u  # ignore errors in virtualenv's activate
 source "$VENV/bin/activate"
 set -u
 
-black $@ cpp/cmake dev/bump
+black $@ cpp/cmake dev/bump cpp/formatting
 

--- a/.github/workflows/check_code_formatting.yml
+++ b/.github/workflows/check_code_formatting.yml
@@ -1,0 +1,17 @@
+name: check-code-formatting
+on: [pull_request, push]
+
+jobs:
+  build:
+    name: check-code-formatting
+    runs-on: ubuntu-20.04
+    # Run on external PRs, but not internal PRs as they'll be run by the push
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+        - name: Fetch repository
+          uses: actions/checkout@v3
+        - name: Install packages
+          run: sudo apt-get update && sudo apt-get install python3-venv
+        - name: Check code formatting documentation
+          run: .ci/check_code_formatting.sh

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 
 build
 .cmake-format.yaml
+cpp/formatting/.clang-format

--- a/cpp/formatting/Makefile
+++ b/cpp/formatting/Makefile
@@ -1,15 +1,28 @@
+# Targets:
+#
+#   README.md: rebuild the Markdown documentation (default target)
+#
+#   all: alias for README.md
+#
+#   clean: remove top generated files
+#
+#   distclean: clean + remove intermediate files
+#
+
 CLANG_FORMAT ?= clang-format
 PANDOC ?= pandoc
 
 SNIPPETS = $(wildcard snippets/*.cpp)
+CLANG_FORMAT_MAJOR = $(shell $(CLANG_FORMAT) --version | sed -e "s/(.*)//" | awk '{print $$NF}' | awk -v FS=. '{print $$1}')
+CLANG_FORMAT_CONFIG = $(shell for i in `seq $(CLANG_FORMAT_MAJOR) -1 7`; do if [ -f ../clang-format-$$i ] ; then echo ../clang-format-$$i ; break; fi; done)
 
-all: README.html
+all: README.md
 
 clean:
-	$(RM) README.md
+	$(RM) README.md README.html
 
 distclean: clean
-	$(RM) README.html
+	$(RM) .clang-format
 
 # README.html
 .md.html: $<
@@ -17,15 +30,18 @@ distclean: clean
 README.html: github-pandoc.css
 
 # README.md
-README.md: README.md.jinja formatting.py $(SNIPPETS)
+README.md: README.md.jinja formatting.py .clang-format $(SNIPPETS)
 	@# format snippets that triggered rebuild of target
-	$(foreach snippet,$(filter snippets/%,$?),$(CLANG_FORMAT) -i $(snippet);)
+	$(foreach snippet,$(filter snippets/%,$?),$(CLANG_FORMAT) -style=file -i $(snippet);)
 
 	./formatting.py $< $@
 
 # update all snippets when .clang-format is changed
-$(SNIPPETS): ../.clang-format-9
-	$(CLANG_FORMAT) -i $@
+$(SNIPPETS): .clang-format
+	$(CLANG_FORMAT) -style=file -i $@
 	touch $@
+
+.clang-format: $(CLANG_FORMAT_CONFIG)
+	cp $? $@
 
 .SUFFIXES: .md .html

--- a/cpp/formatting/formatting.py
+++ b/cpp/formatting/formatting.py
@@ -40,7 +40,7 @@ class Convention(namedtuple("Convention", CONVENTION_ATTRS)):
             if len(fields) == 1:
                 fields = [fields[0], cf_value(fields[0])]
             else:
-                fields[1] = yaml.load(fields[1])
+                fields[1] = yaml.safe_load(fields[1])
             return dict([fields])
 
         with open(file) as istr:
@@ -82,8 +82,8 @@ class Convention(namedtuple("Convention", CONVENTION_ATTRS)):
 
 
 def load_conventions(path):
-    with open("../.clang-format-9") as istr:
-        clang_format = yaml.load(istr)
+    with open(".clang-format") as istr:
+        clang_format = yaml.safe_load(istr)
     assert osp.isdir(path)
     for file in sorted(glob.glob(path + os.sep + "*.cpp")):
         yield Convention.from_file(clang_format, file)


### PR DESCRIPTION
* Use output of `clang-format --version` to figure out the
  proper .clang-format-X file to use.
* Fix deprecation warning by using PyYaml `safe_load` function
* Add GitHub action to check code formatting documentation:
    1. rebuilds the Jinja documentation from scratch
    2. fails README.md is different

fixes #70