### PR TITLE
Update sanitizers.cmake for Apple clang

### DIFF
--- a/cpp/cmake/sanitizers.cmake
+++ b/cpp/cmake/sanitizers.cmake
@@ -62,17 +62,21 @@ function(cpp_cc_enable_sanitizers)
   message(STATUS "Enabling sanitizers: ${${CODING_CONV_PREFIX}_SANITIZERS}")
   # comma-separated string -> CMake list
   string(REPLACE "," ";" sanitizers "${${CODING_CONV_PREFIX}_SANITIZERS}")
-  set(known_undefined_checks
-      undefined
-      float-divide-by-zero
-      unsigned-integer-overflow
-      implicit-integer-sign-change
-      implicit-signed-integer-truncation
-      implicit-unsigned-integer-truncation
-      local-bounds
-      nullability-arg
-      nullability-assign
-      nullability-return)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    set(known_undefined_checks undefined)
+  else()
+    set(known_undefined_checks
+        undefined
+        float-divide-by-zero
+        unsigned-integer-overflow
+        implicit-integer-sign-change
+        implicit-signed-integer-truncation
+        implicit-unsigned-integer-truncation
+        local-bounds
+        nullability-arg
+        nullability-assign
+        nullability-return)
+  endif()
   # Use the shared library version of the sanitizer runtime so that we can LD_PRELOAD it when
   # launching via Python and so on
   set(compiler_flags -fno-omit-frame-pointer -shared-libsan)


### PR DESCRIPTION
Apple's LLVM fork deals with UBSan flags slightly different than the upstream implementation. First of all, when the UBSan is enabled, all available checks are enabled by default, secondly not all checks from LLVM are available.

https://developer.apple.com/documentation/xcode/diagnosing-memory-thread-and-crash-issues-early

This patch sets UBSan compiler flags accordingly when detecting AppleClang.