### PR TITLE
clang-tidy-related fixes

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -79,7 +79,7 @@ function(cpp_cc_enable_static_analysis)
       CACHE STRING "list of CMake targets to build before checking C/C++ code")
   mark_as_advanced(${CODING_CONV_PREFIX}_ClangTidy_DEPENDENCIES)
   set(clang_tidy_command ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/../bin/clang-tidy" -p
-                         ${PROJECT_BINARY_DIR}/compile_commands.json check)
+                         ${PROJECT_BINARY_DIR}/compile_commands.json)
   cpp_cc_add_tool_target(clang-tidy ${clang_tidy_command})
   if(${CODING_CONV_PREFIX}_TEST_STATIC_ANALYSIS)
     add_test(NAME ClangTidy_${PROJECT_NAME} COMMAND ${clang_tidy_command})

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -64,11 +64,17 @@ function(cpp_cc_setup_tool_config name path)
 endfunction()
 
 function(cpp_cc_add_tool_target name)
-  add_custom_target(${name}-${PROJECT_NAME} ${ARGN})
+  add_custom_target(
+    ${name}-${PROJECT_NAME}
+    ${ARGN}
+    JOB_POOL console)
   if(TARGET ${name})
     add_dependencies(${name} ${name}-${PROJECT_NAME})
   else()
-    add_custom_target(${name} DEPENDS ${name}-${PROJECT_NAME})
+    add_custom_target(
+      ${name}
+      DEPENDS ${name}-${PROJECT_NAME}
+      JOB_POOL console)
   endif()
 endfunction()
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -67,7 +67,8 @@ function(cpp_cc_add_tool_target name)
   add_custom_target(
     ${name}-${PROJECT_NAME}
     ${ARGN}
-    JOB_POOL console)
+    JOB_POOL console
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
   if(TARGET ${name})
     add_dependencies(${name} ${name}-${PROJECT_NAME})
   else()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -78,7 +78,7 @@ function(cpp_cc_enable_static_analysis)
       ""
       CACHE STRING "list of CMake targets to build before checking C/C++ code")
   mark_as_advanced(${CODING_CONV_PREFIX}_ClangTidy_DEPENDENCIES)
-  set(clang_tidy_command ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/../bin/clang-tidy" -p
+  set(clang_tidy_command ${PYTHON_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/../bin/clang-tidy" -v -p
                          ${PROJECT_BINARY_DIR}/compile_commands.json)
   cpp_cc_add_tool_target(clang-tidy ${clang_tidy_command})
   if(${CODING_CONV_PREFIX}_TEST_STATIC_ANALYSIS)

--- a/cpp/lib.py
+++ b/cpp/lib.py
@@ -1199,11 +1199,7 @@ class BBPProject:
             cmd += src_dirs
             log_command(cmd)
             if not sources or src_dirs:
-                cwd = source_dir()
-                logging.debug("Executing in {}".format(cwd))
-                git_ls_tree = (
-                    subprocess.check_output(cmd, cwd=cwd).decode("utf-8").split("\0")
-                )
+                git_ls_tree = subprocess.check_output(cmd).decode("utf-8").split("\0")
         else:
             git_ls_tree = []
 

--- a/cpp/lib.py
+++ b/cpp/lib.py
@@ -642,21 +642,16 @@ class Tool(metaclass=abc.ABCMeta):
         call_kwargs = dict(cwd=cwd)
         if logging.getLogger().level > logging.INFO:
             call_kwargs.update(stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        if dry_run:
-            cmd = cmd + self.cmd_opts(task, **kwargs) + list(files)
-            log_command(cmd, logger=self.job_logger, level=logging.INFO)
-            status = subprocess.call(cmd, **call_kwargs)
-            if status != 0:
-                lang_str = "/".join(task_config["languages"])
-                logging.error(
-                    "%s | Incorrect formatting (one or more): %s",
-                    lang_str,
-                    " ".join(files),
-                )
-        else:
-            cmd = cmd + self.cmd_opts(task, **kwargs) + list(files)
-            log_command(cmd, logger=self.job_logger, level=logging.INFO)
-            status = subprocess.call(cmd, **call_kwargs)
+        cmd += self.cmd_opts(task, **kwargs) + list(files)
+        log_command(cmd, logger=self.job_logger, level=logging.INFO)
+        status = subprocess.call(cmd, **call_kwargs)
+        if dry_run and status != 0:
+            lang_str = "/".join(task_config["languages"])
+            logging.error(
+                "%s | failed checks (one or more): %s",
+                lang_str,
+                " ".join(files),
+            )
         return 1 if status != 0 else 0
 
     def accepts_file(self, file: str) -> bool:

--- a/cpp/lib.py
+++ b/cpp/lib.py
@@ -1204,7 +1204,11 @@ class BBPProject:
             cmd += src_dirs
             log_command(cmd)
             if not sources or src_dirs:
-                git_ls_tree = subprocess.check_output(cmd).decode("utf-8").split("\0")
+                cwd = source_dir()
+                logging.debug("Executing in {}".format(cwd))
+                git_ls_tree = (
+                    subprocess.check_output(cmd, cwd=cwd).decode("utf-8").split("\0")
+                )
         else:
             git_ls_tree = []
 


### PR DESCRIPTION
- Run custom targets for tools like `clang-tidy` in the source directory, so `git ls-tree` works sensibly.
- Run custom targets for tools like `clang-tidy` in the `console` pool for Ninja, meaning that output is not buffered.
- Make `clang-tidy` output useful by passing `-v`, remove erroneous `check` positional argument.
- Slightly de-duplicate some Python library code.