### PR TITLE
Improve support for sanitizers with AppleClang

### DIFF
--- a/cpp/cmake/sanitizers.cmake
+++ b/cpp/cmake/sanitizers.cmake
@@ -17,7 +17,7 @@ set(${CODING_CONV_PREFIX}_SANITIZERS_UNDEFINED_EXCLUSIONS
 function(cpp_cc_find_sanitizer_runtime)
   cmake_parse_arguments("" "" "NAME;OUTPUT" "" ${ARGN})
   set(name_template ${CMAKE_SHARED_LIBRARY_PREFIX}clang_rt.)
-  if(APPLE)
+  if(CMAKE_CXX_COMPILER STREQUAL "AppleClang")
     string(APPEND name_template ${_NAME}_osx_dynamic)
   else()
     string(APPEND name_template ${_NAME}-${CMAKE_SYSTEM_PROCESSOR})

--- a/cpp/cmake/sanitizers.cmake
+++ b/cpp/cmake/sanitizers.cmake
@@ -17,7 +17,7 @@ set(${CODING_CONV_PREFIX}_SANITIZERS_UNDEFINED_EXCLUSIONS
 function(cpp_cc_find_sanitizer_runtime)
   cmake_parse_arguments("" "" "NAME;OUTPUT" "" ${ARGN})
   set(name_template ${CMAKE_SHARED_LIBRARY_PREFIX}clang_rt.)
-  if(CMAKE_CXX_COMPILER STREQUAL "AppleClang")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     string(APPEND name_template ${_NAME}_osx_dynamic)
   else()
     string(APPEND name_template ${_NAME}-${CMAKE_SYSTEM_PROCESSOR})

--- a/cpp/cmake/sanitizers.cmake
+++ b/cpp/cmake/sanitizers.cmake
@@ -56,8 +56,8 @@ endfunction()
 #   **disable** sanitizers at runtime. This might be useful if, for example, some part of the
 #   instrumented application is used during the build and you don't want memory leaks to cause build
 #   failures.
-# * ${CODING_CONV_PREFIX}_SANITIZER_PRELOAD_VAR: the environment variable used
-#   to load the sanitizer runtime library. This is typically LD_PRELOAD or DYLD_INSERT_LIBRARIES.
+# * ${CODING_CONV_PREFIX}_SANITIZER_PRELOAD_VAR: the environment variable used to load the sanitizer
+#   runtime library. This is typically LD_PRELOAD or DYLD_INSERT_LIBRARIES.
 # * ${CODING_CONV_PREFIX}_SANITIZER_LIBRARY_PATH: the sanitizer runtime library. This sometimes
 #   needs to be added to ${CODING_CONV_PREFIX}_SANITIZER_PRELOAD_VAR.
 # * ${CODING_CONV_PREFIX}_SANITIZER_LIBRARY_DIR: the directory where the sanitizer runtime library
@@ -189,8 +189,8 @@ endfunction(cpp_cc_enable_sanitizers)
 #
 # * TARGET: list of targets to modify
 # * TEST: list of tests to modify
-# * PRELOAD: if passed, ${CODING_CONV_PREFIX}_SANITIZER_PRELOAD_VAR will be set to the sanitizer runtime library and LD_LIBRARY_PATH
-#   will not be modified
+# * PRELOAD: if passed, ${CODING_CONV_PREFIX}_SANITIZER_PRELOAD_VAR will be set to the sanitizer
+#   runtime library and LD_LIBRARY_PATH will not be modified
 function(cpp_cc_configure_sanitizers)
   cmake_parse_arguments("" "PRELOAD" "" "TARGET;TEST" ${ARGN})
   foreach(target ${_TARGET})
@@ -210,7 +210,10 @@ function(cpp_cc_configure_sanitizers)
       set_property(
         TEST ${test}
         APPEND
-        PROPERTY ENVIRONMENT ${CODING_CONV_PREFIX}_SANITIZER_PRELOAD_VAR=${${CODING_CONV_PREFIX}_SANITIZER_LIBRARY_PATH})
+        PROPERTY
+          ENVIRONMENT
+          ${CODING_CONV_PREFIX}_SANITIZER_PRELOAD_VAR=${${CODING_CONV_PREFIX}_SANITIZER_LIBRARY_PATH}
+      )
     endif()
     # This should be sanitizer-specific stuff like UBSAN_OPTIONS, so we don't need to worry about
     # merging it with an existing value.
@@ -221,9 +224,8 @@ function(cpp_cc_configure_sanitizers)
   endforeach()
 endfunction(cpp_cc_configure_sanitizers)
 
-# Helper function strips away Python shims on macOS, so we can launch tests
-# using the actual Python binary. Without this, preloading the sanitizer
-# runtimes does not work on macOS.
+# Helper function strips away Python shims on macOS, so we can launch tests using the actual Python
+# binary. Without this, preloading the sanitizer runtimes does not work on macOS.
 #
 # cpp_cc_strip_python_shims(EXECUTABLE <executable> OUTPUT <output_variable>)
 #
@@ -235,20 +237,22 @@ function(cpp_cc_strip_python_shims)
   cmake_parse_arguments("" "" "EXECUTABLE;OUTPUT" "" ${ARGN})
   if(APPLE AND ${CODING_CONV_PREFIX}_SANITIZERS)
     # https://jonasdevlieghere.com/sanitizing-python-modules/
-    # "import ctypes; dyld = ctypes.cdll.LoadLibrary('/usr/lib/system/libdyld.dylib'); namelen = ctypes.c_ulong(1024); name = ctypes.create_string_buffer(b'\\000', namelen.value); dyld._NSGetExecutablePath(ctypes.byref(name), ctypes.byref(namelen)); print(name.value.decode())"
-    set(python_script "import ctypes" "dyld = ctypes.cdll.LoadLibrary('/usr/lib/system/libdyld.dylib')"
-    "namelen = ctypes.c_ulong(1024)" "name = ctypes.create_string_buffer(b'\\000', namelen.value)"
-    "dyld._NSGetExecutablePath(ctypes.byref(name), ctypes.byref(namelen))"
-    "print(name.value.decode())")
+    set(python_script
+        "import ctypes"
+        "dyld = ctypes.cdll.LoadLibrary('/usr/lib/system/libdyld.dylib')"
+        "namelen = ctypes.c_ulong(1024)"
+        "name = ctypes.create_string_buffer(b'\\000', namelen.value)"
+        "dyld._NSGetExecutablePath(ctypes.byref(name), ctypes.byref(namelen))"
+        "print(name.value.decode())")
     string(JOIN "; " python_command ${python_script})
     execute_process(
-    COMMAND ${_EXECUTABLE} -c "${python_command}"
-    RESULT_VARIABLE python_status
-    OUTPUT_VARIABLE actual_executable
-    ERROR_VARIABLE python_stderr
-    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
+      COMMAND ${_EXECUTABLE} -c "${python_command}"
+      RESULT_VARIABLE python_status
+      OUTPUT_VARIABLE actual_executable
+      ERROR_VARIABLE python_stderr
+      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_STRIP_TRAILING_WHITESPACE)
     if(NOT python_status EQUAL 0)
-      message(FATAL_ERROR "python_status=${python_status} python_stderr=${python_stderr} actual_executable=${actual_executable}")
+      message(FATAL_ERROR "stdout: ${actual_executable}, stderr: ${python_stderr}")
     endif()
     if(NOT _EXECUTABLE STREQUAL actual_executable)
       message(STATUS "Resolved shim ${_EXECUTABLE} to ${actual_executable}")
@@ -256,7 +260,9 @@ function(cpp_cc_strip_python_shims)
   else()
     set(actual_executable "${_EXECUTABLE}")
   endif()
-  set(${_OUTPUT} "${actual_executable}" PARENT_SCOPE)
+  set(${_OUTPUT}
+      "${actual_executable}"
+      PARENT_SCOPE)
 endfunction()
 
 if(${CODING_CONV_PREFIX}_SANITIZERS)

--- a/cpp/cmake/sanitizers.cmake
+++ b/cpp/cmake/sanitizers.cmake
@@ -128,10 +128,8 @@ function(cpp_cc_enable_sanitizers)
     list(APPEND compiler_flags -fsanitize=address -fsanitize-address-use-after-scope)
     # Figure out where the runtime library lives
     cpp_cc_find_sanitizer_runtime(NAME asan OUTPUT runtime_library)
-    # TODO only on macOS
-    set(extra_env "MallocNanoZone=1")
     if(LLVM_SYMBOLIZER_PATH)
-      list(APPEND extra_env "ASAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER_PATH}")
+      set(extra_env "ASAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER_PATH}")
       if("leak" IN_LIST sanitizers)
         list(APPEND extra_env "LSAN_SYMBOLIZER_PATH=${LLVM_SYMBOLIZER_PATH}")
       endif()
@@ -225,7 +223,9 @@ function(cpp_cc_configure_sanitizers)
 endfunction(cpp_cc_configure_sanitizers)
 
 # Helper function strips away Python shims on macOS, so we can launch tests using the actual Python
-# binary. Without this, preloading the sanitizer runtimes does not work on macOS.
+# binary. Without this, preloading the sanitizer runtimes does not work on macOS. See
+# https://jonasdevlieghere.com/sanitizing-python-modules/ and
+# https://tobywf.com/2021/02/python-ext-asan/ for more information.
 #
 # cpp_cc_strip_python_shims(EXECUTABLE <executable> OUTPUT <output_variable>)
 #
@@ -236,7 +236,6 @@ endfunction(cpp_cc_configure_sanitizers)
 function(cpp_cc_strip_python_shims)
   cmake_parse_arguments("" "" "EXECUTABLE;OUTPUT" "" ${ARGN})
   if(APPLE AND ${CODING_CONV_PREFIX}_SANITIZERS)
-    # https://jonasdevlieghere.com/sanitizing-python-modules/
     set(python_script
         "import ctypes"
         "dyld = ctypes.cdll.LoadLibrary('/usr/lib/system/libdyld.dylib')"


### PR DESCRIPTION
- The runtime library name is slightly different with AppleClang than with Clang.
- We need to set `DYLD_INSERT_LIBRARIES` instead of `LD_PRELOAD` on macOS.
- We need to launch tests using the actual Python executable, not a shim, otherwise the preloading will be ignored.