### PR TITLE
Only copy if the files are different.

### DIFF
--- a/cpp/cmake/build-time-copy.cmake
+++ b/cpp/cmake/build-time-copy.cmake
@@ -23,7 +23,7 @@ function(cpp_cc_build_time_copy)
   add_custom_command(
     OUTPUT "${opt_OUTPUT}"
     DEPENDS "${opt_INPUT}"
-    COMMAND ${CMAKE_COMMAND} -E copy "${opt_INPUT}" "${opt_OUTPUT}")
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different "${opt_INPUT}" "${opt_OUTPUT}")
   if(NOT opt_NO_TARGET)
     string(SHA256 target_name "${opt_INPUT};${opt_OUTPUT}")
     set(target_name "build-time-copy-${target_name}")


### PR DESCRIPTION
This might make a difference in compile times. If for example we copy a files like `newton.hpp` unconditionally then every compilation unit which (transitively) depends on `newton.hpp` will need to be recompiled.

If we only copy when `newton.hpp` has changed, we can likely avoid recompiling pointlessly.