### PR TITLE
tiny fix that will stop path search from crashing

### DIFF
--- a/cpp/lib.py
+++ b/cpp/lib.py
@@ -253,7 +253,7 @@ def where(program: str, regex=None, exclude_regex=None, paths=None):
         abs_path = os.path.join(path, program)
         if os.path.exists(abs_path) and os.access(abs_path, os.X_OK):
             yield abs_path
-        if regex:
+        if regex and os.path.exists(path):
             for file_name in os.listdir(path):
                 file_path = os.path.join(path, file_name)
                 if regex.match(file_name) and os.access(file_path, os.X_OK):


### PR DESCRIPTION
If the the PATH environment variable contains non-existant paths, then the path search tool should not fail but simply skip over that entry.